### PR TITLE
Use simplified version of PowerShell classes

### DIFF
--- a/poshgraph.ps1
+++ b/poshgraph.ps1
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$global:ApplicationEntryScriptName = "graph"
+$ApplicationEntryScriptName = "graph"
 . "$psscriptroot/src/lib/stdlib/start-app.ps1"
 
 

--- a/src/app/GraphAuthenticationContext.ps1
+++ b/src/app/GraphAuthenticationContext.ps1
@@ -69,26 +69,27 @@ class GraphAuthenticationContext {
         $this.tenantName = $tenantName
         $this.Token = $null
     }
-
-    [object] AcquireToken() {
-        if ($this.Token -eq $null) {
-            if ($this.AuthType -eq 'aad') {
-                $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $this.Authority
-                $redirectUri = "http://localhost"
-
-                # Value of '2' comes from 'Auto' of enumeration [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]
-                $promptBehaviorValueRefreshSession = 2
-
-                $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValueRefreshSession
-                $this.Token = $adalAuthContext.AcquireTokenAsync($this.ResourceAppIdURI, $this.AppId, $redirectUri,  $promptBehavior).Result
-            } else {
-                $msaAuthContext = New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $this.AppId
-                $scopes = new-object System.Collections.Generic.List[string]
-                $scopes.Add("User.Read")
-                $this.Token = $msaAuthContext.AcquireTokenAsync($scopes).Result
-            }
-        }
-        return $this.Token
-    }
 }
+
+function GraphAuthenticationContext_AcquireToken([GraphAuthenticationContext] $_this) {
+    if ($_this.Token -eq $null) {
+        if ($_this.AuthType -eq 'aad') {
+            $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $_this.Authority
+            $redirectUri = "http://localhost"
+
+            # Value of '2' comes from 'Auto' of enumeration [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]
+            $promptBehaviorValueRefreshSession = 2
+
+            $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValueRefreshSession
+            $_this.Token = $adalAuthContext.AcquireTokenAsync($_this.ResourceAppIdURI, $_this.AppId, $redirectUri,  $promptBehavior).Result
+        } else {
+            $msaAuthContext = New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $_this.AppId
+            $scopes = new-object System.Collections.Generic.List[string]
+            $scopes.Add("User.Read")
+            $_this.Token = $msaAuthContext.AcquireTokenAsync($scopes).Result
+        }
+    }
+    $_this.Token
+}
+
 

--- a/src/app/GraphAuthenticationContext.ps1
+++ b/src/app/GraphAuthenticationContext.ps1
@@ -14,82 +14,85 @@
 
 include-source "src/app/common/assemblyhelper"
 
-class GraphAuthenticationContext {
-    $AppId
-    $Authority
-    $AuthType
-    $ResourceAppIdUri
-    $TenantName
-    $Token
+function GraphAuthenticationContext($method = $null) {
+    class GraphAuthenticationContext {
+        $AppId
+        $Authority
+        $AuthType
+        $ResourceAppIdUri
+        $TenantName
+        $Token
 
-    GraphAuthenticationContext($authType = 'msa', $appId, $tenantName = $null, $resourceAppIdUri = $null, $altAuthority = $null) {
+        GraphAuthenticationContext($authType = 'msa', $appId, $tenantName = $null, $resourceAppIdUri = $null, $altAuthority = $null) {
 
-        if ($appId -eq $null) {
-            throw "A mandatory appId was not specified"
-        }
-
-        $validAuthTypes = @('msa', 'aad')
-        if (-not $authType -in $validAuthTypes) {
-            throw "Invalid auth type '$authType' was specified -- must be one of '$(validAuthTypes -join ',')'"
-        }
-
-        if ($authType -eq 'msa' -and $tenantName -ne $null) {
-            throw "Tenant '$tenantName' was specified when authentication type 'msa' requires tenant to be unspecified."
-        }
-
-        $authorityValue = $altAuthority
-
-        if ($authType -eq 'aad') {
-            if ($tenantName -eq $null) {
-                throw "A tenant name must be specified for authentication type 'aad'"
+            if ($appId -eq $null) {
+                throw "A mandatory appId was not specified"
             }
 
-            if ($resourceAppIdUri -eq $null) {
-                throw "A resource AppId URI must be specified for authentication type 'aad'"
+            $validAuthTypes = @('msa', 'aad')
+            if (-not $authType -in $validAuthTypes) {
+                throw "Invalid auth type '$authType' was specified -- must be one of '$(validAuthTypes -join ',')'"
             }
 
-            if ($authorityValue -eq $null) {
-                $authorityValue = "https://login.windows.net/$tenantName"
+            if ($authType -eq 'msa' -and $tenantName -ne $null) {
+                throw "Tenant '$tenantName' was specified when authentication type 'msa' requires tenant to be unspecified."
             }
 
-            LoadLatestVersionOfAssembly Microsoft.IdentityModel.Clients.ActiveDirectory.dll
-        } else {
-            if ($altAuthority -ne $null) {
-                throw "An authority must *not* be specified for authentication type 'msa'"
+            $authorityValue = $altAuthority
+
+            if ($authType -eq 'aad') {
+                if ($tenantName -eq $null) {
+                    throw "A tenant name must be specified for authentication type 'aad'"
+                }
+
+                if ($resourceAppIdUri -eq $null) {
+                    throw "A resource AppId URI must be specified for authentication type 'aad'"
+                }
+
+                if ($authorityValue -eq $null) {
+                    $authorityValue = "https://login.windows.net/$tenantName"
+                }
+
+                LoadLatestVersionOfAssembly Microsoft.IdentityModel.Clients.ActiveDirectory.dll
+            } else {
+                if ($altAuthority -ne $null) {
+                    throw "An authority must *not* be specified for authentication type 'msa'"
+                }
+                $scriptDirectory = split-path -parent $pscommandpath
+
+                LoadLatestVersionOfAssembly Microsoft.Identity.Client.dll
             }
-            $scriptDirectory = split-path -parent $pscommandpath
 
-            LoadLatestVersionOfAssembly Microsoft.Identity.Client.dll
-        }
-
-        $this.AppId = $appId
-        $this.Authority = $authorityValue
-        $this.AuthType = $authType
-        $this.ResourceAppIdUri = $resourceAppIdUri
-        $this.tenantName = $tenantName
-        $this.Token = $null
-    }
-}
-
-function GraphAuthenticationContext_AcquireToken([GraphAuthenticationContext] $_this) {
-    if ($_this.Token -eq $null) {
-        if ($_this.AuthType -eq 'aad') {
-            $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $_this.Authority
-            $redirectUri = "http://localhost"
-
-            # Value of '2' comes from 'Auto' of enumeration [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]
-            $promptBehaviorValueRefreshSession = 2
-
-            $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValueRefreshSession
-            $_this.Token = $adalAuthContext.AcquireTokenAsync($_this.ResourceAppIdURI, $_this.AppId, $redirectUri,  $promptBehavior).Result
-        } else {
-            $msaAuthContext = New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $_this.AppId
-            $scopes = new-object System.Collections.Generic.List[string]
-            $scopes.Add("User.Read")
-            $_this.Token = $msaAuthContext.AcquireTokenAsync($scopes).Result
+            $this.AppId = $appId
+            $this.Authority = $authorityValue
+            $this.AuthType = $authType
+            $this.ResourceAppIdUri = $resourceAppIdUri
+            $this.tenantName = $tenantName
+            $this.Token = $null
         }
     }
-    $_this.Token
-}
 
+    function AcquireToken([GraphAuthenticationContext] $_this) {
+        if ($_this.Token -eq $null) {
+            if ($_this.AuthType -eq 'aad') {
+                $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $_this.Authority
+                $redirectUri = "http://localhost"
+
+                # Value of '2' comes from 'Auto' of enumeration [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]
+                $promptBehaviorValueRefreshSession = 2
+
+                $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValueRefreshSession
+                $_this.Token = $adalAuthContext.AcquireTokenAsync($_this.ResourceAppIdURI, $_this.AppId, $redirectUri,  $promptBehavior).Result
+            } else {
+                $msaAuthContext = New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $_this.AppId
+                $scopes = new-object System.Collections.Generic.List[string]
+                $scopes.Add("User.Read")
+                $_this.Token = $msaAuthContext.AcquireTokenAsync($scopes).Result
+            }
+        }
+        $_this.Token
+    }
+
+    . $define_class @args
+}
 

--- a/src/app/GraphConnection.ps1
+++ b/src/app/GraphConnection.ps1
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 include-source "src/app/GraphContext"
+include-source "src/app/GraphAuthenticationContext"
 
 class GraphConnection {
     $Context
     $Connected = $false
 
     GraphConnection($graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint = $null, $altAuthority = $null) {
-        $this.Context = [GraphContext]::new($graphType, $authtype, $tenantName, $altAppId, $altEndpoint, $altAuthority)
-    }
-
-    Connect() {
-        if ( ! $this.Connected ) {
-            $this.Context.AuthContext.AcquireToken() | out-null
-            $this.Connected = $true
-        }
+        $this.Context = new-object "GraphContext" -argumentlist ($graphType, $authtype, $tenantName, $altAppId, $altEndpoint, $altAuthority)
     }
 }
+
+function GraphConnection_Connect([GraphConnection] $_this) {
+    if ( ! $_this.Connected ) {
+        GraphAuthenticationContext_AcquireToken $_this.Context.AuthContext | out-null
+        $_this.Connected = $true
+    }
+}
+

--- a/src/app/GraphConnection.ps1
+++ b/src/app/GraphConnection.ps1
@@ -16,19 +16,23 @@
 include-source "src/app/GraphContext"
 include-source "src/app/GraphAuthenticationContext"
 
-class GraphConnection {
-    $Context
-    $Connected = $false
+function GraphConnection($method = $null) {
+    class GraphConnection {
+        $Context
+        $Connected = $false
 
-    GraphConnection($graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint = $null, $altAuthority = $null) {
-        $this.Context = new-object "GraphContext" -argumentlist ($graphType, $authtype, $tenantName, $altAppId, $altEndpoint, $altAuthority)
+        GraphConnection($graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint = $null, $altAuthority = $null) {
+            $this.Context = GraphContext new $graphType $authtype $tenantName $altAppId $altEndpoint $altAuthority
+        }
     }
-}
 
-function GraphConnection_Connect([GraphConnection] $_this) {
-    if ( ! $_this.Connected ) {
-        GraphAuthenticationContext_AcquireToken $_this.Context.AuthContext | out-null
-        $_this.Connected = $true
+    function Connect($_this) {
+        if ( ! $_this.Connected ) {
+            GraphAuthenticationContext AcquireToken $_this.Context.AuthContext | out-null
+            $_this.Connected = $true
+        }
     }
+
+    . $define_class @args
 }
 

--- a/src/app/GraphConnection.ps1
+++ b/src/app/GraphConnection.ps1
@@ -22,7 +22,7 @@ function GraphConnection($method = $null) {
         $Connected = $false
 
         GraphConnection($graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint = $null, $altAuthority = $null) {
-            $this.Context = GraphContext new $graphType $authtype $tenantName $altAppId $altEndpoint $altAuthority
+            $this.Context = GraphContext __new $graphType $authtype $tenantName $altAppId $altEndpoint $altAuthority
         }
     }
 

--- a/src/app/GraphContext.ps1
+++ b/src/app/GraphContext.ps1
@@ -158,7 +158,7 @@ function GraphContext($method = $null) {
             }
         }
 
-        $_this.AuthContext = (GraphAuthenticationContext)::new($authType, $appId, $tenantName, $resourceAppIdUri, $altAuthority)
+        $_this.AuthContext = GraphAuthenticationContext new $authType $appId $tenantName $resourceAppIdUri $altAuthority
     }
 
     function GetRestAPIHeader($token) {

--- a/src/app/GraphContext.ps1
+++ b/src/app/GraphContext.ps1
@@ -158,7 +158,7 @@ function GraphContext($method = $null) {
             }
         }
 
-        $_this.AuthContext = GraphAuthenticationContext new $authType $appId $tenantName $resourceAppIdUri $altAuthority
+        $_this.AuthContext = GraphAuthenticationContext __new $authType $appId $tenantName $resourceAppIdUri $altAuthority
     }
 
     function GetRestAPIHeader($token) {

--- a/src/app/GraphContext.ps1
+++ b/src/app/GraphContext.ps1
@@ -19,153 +19,156 @@ class GraphContext {
     $Endpoint
     $GraphType
 
-    static [string] GetGraphEndpoint($graphType, $alternateEndpoint) {
-        [GraphContext]::ValidateGraphType($graphType)
-        $result = if ( $alternateEndpoint -ne $null ) {
-            $alternateEndpoint
-        } elseif ( $graphType -eq 'msgraph' ) {
-            [GraphContext]::MSGraphEndpoint()
-        } else {
-            [GraphContext]::AADGraphEndpoint()
-        }
-        return $result
-    }
-
-    static [string] AADGraphEndpoint() {
-        return "https://graph.windows.net"
-    }
-
-    static [string] MSGraphEndpoint() {
-        return "https://graph.microsoft.com/v1.0"
-    }
-
-    static [string] AADGraphAppId() {
-        return "42c41bc4-75da-4142-91d7-baf15cc24fb9"
-    }
-
-    static [string] MSGraphAppId() {
-        return "01e45b18-f1e5-4e66-b2db-09ce7909b99d"
-    }
-
-    static [string] GetTenantEndpointComponent($graphType, $endpointRoot, $tenantName) {
-        $result = if ($graphType -eq 'adgraph') {
-            if ( $tenantName -eq $null) {
-                throw "No tenant was specified for the ad graph endpoint"
-            }
-            $endpointRoot + "/$tenantName"
-        } else {
-            $endpointRoot
-        }
-
-        return $result
-    }
-
-    static [string] GetUriQueryComponent($graphType, $query = $null) {
-        $result = ""
-        $querySeparator = '?'
-        if ($graphType -eq 'adgraph') {
-            $result = "?api-version=1.6"
-            $querySeparator = '&'
-        }
-
-        if ($query -ne $null) {
-            $result += ($querySeparator + $query)
-        }
-
-        return $result
-    }
-
-    static [string] RestAPIResourceUri($endpoint, $resource, $query) {
-        $strictUri = "$endpoint/$resource"
-
-        $result = if ($query -eq $null) {
-            $strictUri
-        } else {
-            "$($strictUri)$($query)"
-        }
-
-        return $result
-    }
-
-    static [string] RestAPIResourceUriForGraph($graphType, $endpointRoot, $tenantName, $resource, $query) {
-        $graphEndpoint = [GraphContext]::GetTenantEndpointComponent($graphType, $endpointRoot, $tenantName)
-        $queryComponent = [GraphContext]::GetUriQueryComponent($graphType, $query)
-        return [GraphContext]::RestAPIResourceUri($graphEndpoint, $resource, $queryComponent)
-    }
-
-    InitializeGraphType($graphType) {
-        [GraphContext]::ValidateGraphType($graphType)
-        $this.GraphType = $graphType
-    }
-
     GraphContext($graphType = 'msgraph', $authContext) {
         $this.Endpoint = $null
         $this.AuthContext = $authContext
-        $this.InitializeGraphType($graphType)
+        GraphContext_InitializeGraphType $this $graphType
     }
 
     GraphContext($graphType = 'msgraph', $authType = 'msa',  $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-        $this.InitializeGraphType($graphType)
-        $this.Endpoint = [GraphContext]::GetGraphEndpoint($graphType, $alternateEndpoint)
-        $this.InitializeAuth($graphType, $authType, $tenantName, $alternateAppId, $alternateEndpoint, $alternateAuthority)
-    }
-
-    static ValidateGraphType($graphType) {
-        $validGraphs = @('msgraph', 'adgraph')
-        if (-not $graphType -in $validGraphs) {
-            throw "Invalid graph type '$graphType' was specified -- must be one of '$($validGraphs -join ',')'"
-        }
-    }
-    InitializeAuth($graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint, $altAuthority = $null) {
-        $resourceAppIdUri = if ($authType -eq 'aad') {
-            [GraphContext]::GetGraphEndpoint($graphType, $altEndpoint)
-        } else {
-            $null
-        }
-
-        $appId = $altAppId
-
-        if ($appId -eq $null) {
-            $appId = if ($graphType -eq 'adgraph') {
-                [GraphContext]::AADGraphAppId()
-            } else {
-                [GraphContext]::MSGraphAppId()
-            }
-        }
-
-        $this.AuthContext = [GraphAuthenticationContext]::new($authType, $appId, $tenantName, $resourceAppIdUri, $altAuthority)
-    }
-
-    [object] InvokeRestAPIMethod($uri, $header, $method="GET") {
-        $result = try {
-            Invoke-RestMethod -Uri $uri -Headers $header -method $method
-        } catch {
-            write-error $_.Exception
-            $_.Exception.Response | out-host
-            $null
-        }
-        return $result
-    }
-
-    [object] GetRestAPIHeader($token) {
-        # Building Rest Api header with authorization token
-        return @{
-            'Content-Type'='application\json'
-            'Authorization'=$token.CreateAuthorizationHeader()
-        }
-    }
-
-    [object] CallRestAPIMethodForResource($uri, $restAPIHeader) {
-        return $this.InvokeRestAPIMethod($uri, $restAPIHeader, "GET")
-    }
-
-    [object] GetRestAPIResponseForResource($resourceUri, $token, $query = $null) {
-        $restAPIHeader = $this.GetRestAPIHeader($token)
-        $uri = [GraphContext]::RestAPIResourceUriForGraph($this.GraphType, $this.Endpoint, $this.AuthContext.TenantName, $resourceUri, $query)
-       return $this.CallRestAPIMethodForResource($uri, $restAPIHeader)
-    }
-
-    [object] GetGraphAPIResponse($relativeResourceUri, $query = $null) {
-        return $this.GetRestAPIResponseForResource($relativeResourceUri, $this.AuthContext.Token, $query)
+        GraphContext_InitializeGraphType $this $graphType
+        $this.Endpoint = GraphContext_GetGraphEndpoint $graphType $alternateEndpoint
+        GraphContext_InitializeAuth $this $graphType $authType $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
     }
 }
+
+function GraphContext_InitializeGraphType([GraphContext] $_this, $graphType) {
+    GraphContext_ValidateGraphType $graphType
+    $_this.GraphType = $graphType
+}
+
+function GraphContext_GetRestAPIResponseForResource([GraphContext] $_this, $resourceUri, $token, $query = $null) {
+    $restAPIHeader = GraphContext_GetRestAPIHeader $token
+    $uri = GraphContext_RestAPIResourceUriForGraph $_this.GraphType $_this.Endpoint $_this.AuthContext.TenantName $resourceUri $query
+    GraphContext_CallRestAPIMethodForResource $uri $restAPIHeader
+}
+
+function GraphContext_GetGraphAPIResponse([GraphContext] $_this, $relativeResourceUri, $query = $null) {
+    GraphContext_GetRestAPIResponseForResource $_this $relativeResourceUri $_this.AuthContext.Token $query
+}
+
+function GraphContext_CallRestAPIMethodForResource($uri, $restAPIHeader) {
+    GraphContext_InvokeRestAPIMethod $uri $restAPIHeader "GET"
+}
+
+function GraphContext_InvokeRestAPIMethod($uri, $header, $method="GET") {
+    $result = try {
+        Invoke-RestMethod -Uri $uri -Headers $header -method $method
+    } catch {
+        write-error $_.Exception
+        $_.Exception.Response | out-host
+        $null
+    }
+
+    $result
+}
+
+function GraphContext_GetGraphEndpoint($graphType, $alternateEndpoint) {
+    GraphContext_ValidateGraphType $graphType
+    $result = if ( $alternateEndpoint -ne $null ) {
+        $alternateEndpoint
+    } elseif ( $graphType -eq 'msgraph' ) {
+        (GraphContext_MSGraphEndpoint)
+    } else {
+        (GraphContext_AADGraphEndpoint)
+    }
+    $result
+}
+
+function GraphContext_AADGraphEndpoint() {
+    "https://graph.windows.net"
+}
+
+function GraphContext_MSGraphEndpoint() {
+    "https://graph.microsoft.com/v1.0"
+}
+
+function GraphContext_AADGraphAppId() {
+    "42c41bc4-75da-4142-91d7-baf15cc24fb9"
+}
+
+function GraphContext_MSGraphAppId() {
+    "01e45b18-f1e5-4e66-b2db-09ce7909b99d"
+}
+
+function GraphContext_GetTenantEndpointComponent($graphType, $endpointRoot, $tenantName) {
+    $result = if ($graphType -eq 'adgraph') {
+        if ( $tenantName -eq $null) {
+            throw "No tenant was specified for the ad graph endpoint"
+        }
+        $endpointRoot + "/$tenantName"
+    } else {
+        $endpointRoot
+    }
+
+    $result
+}
+
+function GraphContext_GetUriQueryComponent($graphType, $query = $null) {
+    $result = ""
+    $querySeparator = '?'
+    if ($graphType -eq 'adgraph') {
+        $result = "?api-version=1.6"
+        $querySeparator = '&'
+    }
+
+    if ($query -ne $null) {
+        $result += ($querySeparator + $query)
+    }
+
+    $result
+}
+
+function GraphContext_RestAPIResourceUri($endpoint, $resource, $query) {
+    $strictUri = "$endpoint/$resource"
+
+    $result = if ($query -eq $null) {
+        $strictUri
+    } else {
+        "$($strictUri)$($query)"
+    }
+
+    $result
+}
+
+function GraphContext_RestAPIResourceUriForGraph($graphType, $endpointRoot, $tenantName, $resource, $query) {
+    $graphEndpoint = GraphContext_GetTenantEndpointComponent $graphType $endpointRoot $tenantName
+    $queryComponent = GraphContext_GetUriQueryComponent $graphType $query
+    GraphContext_RestAPIResourceUri $graphEndpoint $resource $queryComponent
+}
+
+function GraphContext_ValidateGraphType($graphType) {
+    $validGraphs = @('msgraph', 'adgraph')
+    if (-not $graphType -in $validGraphs) {
+        throw "Invalid graph type '$graphType' was specified -- must be one of '$($validGraphs -join ',')'"
+    }
+}
+
+function GraphContext_InitializeAuth([GraphContext] $_this, $graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint, $altAuthority = $null) {
+    $resourceAppIdUri = if ($authType -eq 'aad') {
+        GraphContext_GetGraphEndpoint $graphType $altEndpoint
+    } else {
+        $null
+    }
+
+    $appId = $altAppId
+
+    if ($appId -eq $null) {
+        $appId = if ($graphType -eq 'adgraph') {
+            (GraphContext_AADGraphAppId)
+        } else {
+            (GraphContext_MSGraphAppId)
+        }
+    }
+
+    $_this.AuthContext = [GraphAuthenticationContext]::new($authType, $appId, $tenantName, $resourceAppIdUri, $altAuthority)
+}
+
+function GraphContext_GetRestAPIHeader($token) {
+    # Building Rest Api header with authorization token
+    @{
+        'Content-Type'='application\json'
+        'Authorization'=$token.CreateAuthorizationHeader()
+    }
+}
+

--- a/src/app/GraphContext.ps1
+++ b/src/app/GraphContext.ps1
@@ -14,161 +14,167 @@
 
 include-source "src/app/GraphAuthenticationContext"
 
-class GraphContext {
-    $AuthContext
-    $Endpoint
-    $GraphType
+function GraphContext($method = $null) {
 
-    GraphContext($graphType = 'msgraph', $authContext) {
-        $this.Endpoint = $null
-        $this.AuthContext = $authContext
-        GraphContext_InitializeGraphType $this $graphType
-    }
+    class GraphContext {
+        $AuthContext
+        $Endpoint
+        $GraphType
 
-    GraphContext($graphType = 'msgraph', $authType = 'msa',  $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-        GraphContext_InitializeGraphType $this $graphType
-        $this.Endpoint = GraphContext_GetGraphEndpoint $graphType $alternateEndpoint
-        GraphContext_InitializeAuth $this $graphType $authType $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
-    }
-}
-
-function GraphContext_InitializeGraphType([GraphContext] $_this, $graphType) {
-    GraphContext_ValidateGraphType $graphType
-    $_this.GraphType = $graphType
-}
-
-function GraphContext_GetRestAPIResponseForResource([GraphContext] $_this, $resourceUri, $token, $query = $null) {
-    $restAPIHeader = GraphContext_GetRestAPIHeader $token
-    $uri = GraphContext_RestAPIResourceUriForGraph $_this.GraphType $_this.Endpoint $_this.AuthContext.TenantName $resourceUri $query
-    GraphContext_CallRestAPIMethodForResource $uri $restAPIHeader
-}
-
-function GraphContext_GetGraphAPIResponse([GraphContext] $_this, $relativeResourceUri, $query = $null) {
-    GraphContext_GetRestAPIResponseForResource $_this $relativeResourceUri $_this.AuthContext.Token $query
-}
-
-function GraphContext_CallRestAPIMethodForResource($uri, $restAPIHeader) {
-    GraphContext_InvokeRestAPIMethod $uri $restAPIHeader "GET"
-}
-
-function GraphContext_InvokeRestAPIMethod($uri, $header, $method="GET") {
-    $result = try {
-        Invoke-RestMethod -Uri $uri -Headers $header -method $method
-    } catch {
-        write-error $_.Exception
-        $_.Exception.Response | out-host
-        $null
-    }
-
-    $result
-}
-
-function GraphContext_GetGraphEndpoint($graphType, $alternateEndpoint) {
-    GraphContext_ValidateGraphType $graphType
-    $result = if ( $alternateEndpoint -ne $null ) {
-        $alternateEndpoint
-    } elseif ( $graphType -eq 'msgraph' ) {
-        (GraphContext_MSGraphEndpoint)
-    } else {
-        (GraphContext_AADGraphEndpoint)
-    }
-    $result
-}
-
-function GraphContext_AADGraphEndpoint() {
-    "https://graph.windows.net"
-}
-
-function GraphContext_MSGraphEndpoint() {
-    "https://graph.microsoft.com/v1.0"
-}
-
-function GraphContext_AADGraphAppId() {
-    "42c41bc4-75da-4142-91d7-baf15cc24fb9"
-}
-
-function GraphContext_MSGraphAppId() {
-    "01e45b18-f1e5-4e66-b2db-09ce7909b99d"
-}
-
-function GraphContext_GetTenantEndpointComponent($graphType, $endpointRoot, $tenantName) {
-    $result = if ($graphType -eq 'adgraph') {
-        if ( $tenantName -eq $null) {
-            throw "No tenant was specified for the ad graph endpoint"
+        GraphContext($graphType = 'msgraph', $authContext) {
+            $this.Endpoint = $null
+            $this.AuthContext = $authContext
+            InitializeGraphType $this $graphType
         }
-        $endpointRoot + "/$tenantName"
-    } else {
-        $endpointRoot
+
+        GraphContext($graphType = 'msgraph', $authType = 'msa',  $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
+            InitializeGraphType $this $graphType
+            $this.Endpoint = GetGraphEndpoint $graphType $alternateEndpoint
+            InitializeAuth $this $graphType $authType $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
+        }
     }
 
-    $result
-}
-
-function GraphContext_GetUriQueryComponent($graphType, $query = $null) {
-    $result = ""
-    $querySeparator = '?'
-    if ($graphType -eq 'adgraph') {
-        $result = "?api-version=1.6"
-        $querySeparator = '&'
+    function GetRestAPIResponseForResource($_this, $resourceUri, $token, $query = $null) {
+        $restAPIHeader = GetRestAPIHeader $token
+        $uri = RestAPIResourceUriForGraph $_this.GraphType $_this.Endpoint $_this.AuthContext.TenantName $resourceUri $query
+        CallRestAPIMethodForResource $uri $restAPIHeader
     }
 
-    if ($query -ne $null) {
-        $result += ($querySeparator + $query)
+    function GetGraphAPIResponse($_this, $relativeResourceUri, $query = $null) {
+        GetRestAPIResponseForResource $_this $relativeResourceUri $_this.AuthContext.Token $query
     }
 
-    $result
-}
-
-function GraphContext_RestAPIResourceUri($endpoint, $resource, $query) {
-    $strictUri = "$endpoint/$resource"
-
-    $result = if ($query -eq $null) {
-        $strictUri
-    } else {
-        "$($strictUri)$($query)"
+    function CallRestAPIMethodForResource($uri, $restAPIHeader) {
+        InvokeRestAPIMethod $uri $restAPIHeader "GET"
     }
 
-    $result
-}
+    function InvokeRestAPIMethod($uri, $header, $method="GET") {
+        $result = try {
+            Invoke-RestMethod -Uri $uri -Headers $header -method $method
+        } catch {
+            write-error $_.Exception
+            $_.Exception.Response | out-host
+            $null
+        }
 
-function GraphContext_RestAPIResourceUriForGraph($graphType, $endpointRoot, $tenantName, $resource, $query) {
-    $graphEndpoint = GraphContext_GetTenantEndpointComponent $graphType $endpointRoot $tenantName
-    $queryComponent = GraphContext_GetUriQueryComponent $graphType $query
-    GraphContext_RestAPIResourceUri $graphEndpoint $resource $queryComponent
-}
-
-function GraphContext_ValidateGraphType($graphType) {
-    $validGraphs = @('msgraph', 'adgraph')
-    if (-not $graphType -in $validGraphs) {
-        throw "Invalid graph type '$graphType' was specified -- must be one of '$($validGraphs -join ',')'"
-    }
-}
-
-function GraphContext_InitializeAuth([GraphContext] $_this, $graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint, $altAuthority = $null) {
-    $resourceAppIdUri = if ($authType -eq 'aad') {
-        GraphContext_GetGraphEndpoint $graphType $altEndpoint
-    } else {
-        $null
+        $result
     }
 
-    $appId = $altAppId
-
-    if ($appId -eq $null) {
-        $appId = if ($graphType -eq 'adgraph') {
-            (GraphContext_AADGraphAppId)
+    function GetGraphEndpoint($graphType, $alternateEndpoint) {
+        ValidateGraphType $graphType
+        $result = if ( $alternateEndpoint -ne $null ) {
+            $alternateEndpoint
+        } elseif ( $graphType -eq 'msgraph' ) {
+            (MSGraphEndpoint)
         } else {
-            (GraphContext_MSGraphAppId)
+            (AADGraphEndpoint)
+        }
+        $result
+    }
+
+    function AADGraphEndpoint() {
+        "https://graph.windows.net"
+    }
+
+    function MSGraphEndpoint() {
+        "https://graph.microsoft.com/v1.0"
+    }
+
+    function AADGraphAppId() {
+        "42c41bc4-75da-4142-91d7-baf15cc24fb9"
+    }
+
+    function MSGraphAppId() {
+        "01e45b18-f1e5-4e66-b2db-09ce7909b99d"
+    }
+
+    function GetTenantEndpointComponent($graphType, $endpointRoot, $tenantName) {
+        $result = if ($graphType -eq 'adgraph') {
+            if ( $tenantName -eq $null) {
+                throw "No tenant was specified for the ad graph endpoint"
+            }
+            $endpointRoot + "/$tenantName"
+        } else {
+            $endpointRoot
+        }
+
+        $result
+    }
+
+    function GetUriQueryComponent($graphType, $query = $null) {
+        $result = ""
+        $querySeparator = '?'
+        if ($graphType -eq 'adgraph') {
+            $result = "?api-version=1.6"
+            $querySeparator = '&'
+        }
+
+        if ($query -ne $null) {
+            $result += ($querySeparator + $query)
+        }
+
+        $result
+    }
+
+    function RestAPIResourceUri($endpoint, $resource, $query) {
+        $strictUri = "$endpoint/$resource"
+
+        $result = if ($query -eq $null) {
+            $strictUri
+        } else {
+            "$($strictUri)$($query)"
+        }
+
+        $result
+    }
+
+    function RestAPIResourceUriForGraph($graphType, $endpointRoot, $tenantName, $resource, $query) {
+        $graphEndpoint = GetTenantEndpointComponent $graphType $endpointRoot $tenantName
+        $queryComponent = GetUriQueryComponent $graphType $query
+        RestAPIResourceUri $graphEndpoint $resource $queryComponent
+    }
+
+    function ValidateGraphType($graphType) {
+        $validGraphs = @('msgraph', 'adgraph')
+        if (-not $graphType -in $validGraphs) {
+            throw "Invalid graph type '$graphType' was specified -- must be one of '$($validGraphs -join ',')'"
         }
     }
 
-    $_this.AuthContext = [GraphAuthenticationContext]::new($authType, $appId, $tenantName, $resourceAppIdUri, $altAuthority)
+    function InitializeAuth($_this, $graphType = 'msgraph', $authType = 'msa', $tenantName = $null, $altAppId = $null, $altEndpoint, $altAuthority = $null) {
+        $resourceAppIdUri = if ($authType -eq 'aad') {
+            GetGraphEndpoint $graphType $altEndpoint
+        } else {
+            $null
+        }
+
+        $appId = $altAppId
+
+        if ($appId -eq $null) {
+            $appId = if ($graphType -eq 'adgraph') {
+                (AADGraphAppId)
+            } else {
+                (MSGraphAppId)
+            }
+        }
+
+        $_this.AuthContext = (GraphAuthenticationContext)::new($authType, $appId, $tenantName, $resourceAppIdUri, $altAuthority)
+    }
+
+    function GetRestAPIHeader($token) {
+        # Building Rest Api header with authorization token
+        @{
+            'Content-Type'='application\json'
+            'Authorization'=$token.CreateAuthorizationHeader()
+        }
+    }
+
+    function InitializeGraphType($_this, $graphType) {
+        ValidateGraphType $graphType
+        $_this.GraphType = $graphType
+    }
+
+    . $define_class @args
 }
 
-function GraphContext_GetRestAPIHeader($token) {
-    # Building Rest Api header with authorization token
-    @{
-        'Content-Type'='application\json'
-        'Authorization'=$token.CreateAuthorizationHeader()
-    }
-}
 

--- a/src/app/cmdlets.ps1
+++ b/src/app/cmdlets.ps1
@@ -26,7 +26,7 @@ function Get-MSAAuthContext {
         $appId = [GraphPublicEndpoint]::MSGraphAppId()
     }
 
-    $authContext = GraphAuthenticationContext  new 'msa' $appId $null $null $null
+    $authContext = GraphAuthenticationContext __new 'msa' $appId $null $null $null
     $authContext
 }
 
@@ -51,7 +51,7 @@ function Get-AADAuthContext {
         $appId = [GraphPublicEndpoint]::AADGraphAppId()
     }
 
-    GraphAuthenticationContext new 'aad' $appId $tenantName $resourceAppIdUri $alternateAuthority
+    GraphAuthenticationContext __new 'aad' $appId $tenantName $resourceAppIdUri $alternateAuthority
 }
 
 function New-GraphContext($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
@@ -59,7 +59,7 @@ function New-GraphContext($graphType = 'msgraph', $authtype = 'msa', $tenantName
 }
 
 function New-GraphConnection($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-    GraphConnection new $graphType $authtype $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
+    GraphConnection __new $graphType $authtype $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
 }
 
 function Get-GraphItem($itemRelativeUri, $existingConnection = $null) {

--- a/src/app/cmdlets.ps1
+++ b/src/app/cmdlets.ps1
@@ -71,7 +71,7 @@ function Get-GraphItem($itemRelativeUri, $existingConnection = $null) {
         $existingConnection
     }
 
-    $connection.Connect()
+    GraphConnection_Connect $connection
 
-    $connection.Context.GetGraphAPIResponse($itemRelativeUri, $null)
+    GraphContext_GetGraphAPIResponse $connection.Context $itemRelativeUri $null
 }

--- a/src/app/cmdlets.ps1
+++ b/src/app/cmdlets.ps1
@@ -51,9 +51,7 @@ function Get-AADAuthContext {
         $appId = [GraphPublicEndpoint]::AADGraphAppId()
     }
 
-    $authContext = [GraphAuthenticationContext]::new('aad', $appId,  $tenantName, $resourceAppIdUri, $alternateAuthority)
-
-    $authContext
+    GraphAuthenticationContext new 'aad' $appId $tenantName $resourceAppIdUri $alternateAuthority
 }
 
 function New-GraphContext($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
@@ -61,7 +59,7 @@ function New-GraphContext($graphType = 'msgraph', $authtype = 'msa', $tenantName
 }
 
 function New-GraphConnection($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-    (GraphConnection)::new($graphType, $authtype, $tenantName, $alternateAppId, $alternateEndpoint, $alternateAuthority)
+    GraphConnection new $graphType $authtype $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
 }
 
 function Get-GraphItem($itemRelativeUri, $existingConnection = $null) {

--- a/src/app/cmdlets.ps1
+++ b/src/app/cmdlets.ps1
@@ -26,7 +26,7 @@ function Get-MSAAuthContext {
         $appId = [GraphPublicEndpoint]::MSGraphAppId()
     }
 
-    $authContext = [GraphAuthenticationContext]::new('msa', $appId, $null, $null, $null)
+    $authContext = GraphAuthenticationContext  new 'msa' $appId $null $null $null
     $authContext
 }
 
@@ -57,11 +57,11 @@ function Get-AADAuthContext {
 }
 
 function New-GraphContext($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-    [GraphContext]::new($graphType, $authtype, $tenantName, $alternateAppId, $alternateEndpoint, $alternateAuthority)
+    GraphContext new $graphType $authtype $tenantName $alternateAppId $alternateEndpoint $alternateAuthority
 }
 
 function New-GraphConnection($graphType = 'msgraph', $authtype = 'msa', $tenantName = $null, $alternateAppId = $null, $alternateEndpoint = $null, $alternateAuthority = $null) {
-    [GraphConnection]::new($graphType, $authtype, $tenantName, $alternateAppId, $alternateEndpoint, $alternateAuthority)
+    (GraphConnection)::new($graphType, $authtype, $tenantName, $alternateAppId, $alternateEndpoint, $alternateAuthority)
 }
 
 function Get-GraphItem($itemRelativeUri, $existingConnection = $null) {
@@ -71,7 +71,7 @@ function Get-GraphItem($itemRelativeUri, $existingConnection = $null) {
         $existingConnection
     }
 
-    GraphConnection_Connect $connection
+    GraphConnection Connect $connection
 
-    GraphContext_GetGraphAPIResponse $connection.Context $itemRelativeUri $null
+    GraphContext GetGraphAPIResponse $connection.Context $itemRelativeUri $null
 }

--- a/src/lib/stdlib/README-stdlib.md
+++ b/src/lib/stdlib/README-stdlib.md
@@ -1,0 +1,205 @@
+Enhanced Standard Library (stdlib) for PowerShell
+=================================================
+This Enhanced Standard Library (stdlib) provides code re-use capabilities and syntactic affordances for PowerShell similar to comparable dynamic languages such as PowerShell. The overall aim is to facilitate the development of PowerShell-based applications rather than just scripts or utilities that comprise the typical PowerShell use case.
+
+## Features
+The library features the following enhancements for PowerShell applications
+
+* The `include-source` cmdlet that allows the use of code (i.e. functions, classes, variables, etc.) from external PowerShell files within the calling PowerShell file. It is similar in function to the Ruby `require` method or Python's `import` keyword.
+* An additional `$ApplicationRoot` "automatic" variable indicating the directory in which the script that launched the application resides.
+* Automatic enforcement of PowerShell `strict mode 2`.
+* A simple calling convention for using PowerShell's *class* capability for complex type abstraction while still allowing the PowerShell cmdlet/function invocation syntax
+
+### Using the library's *class* feature
+
+The ability to define classes of objects is a very useful one across a spectrum of languages including C++, C#, Java, Ruby, Python, and many others. Even without strict conformance to object-oriented rigor, there are cognitive benefits to developers in abstracting detailed state into higher level concepts and explicitly defining the allowed operations upon those concepts. Classes enhance code readability and foster understanding of code and an easier ability to reason about it and how to change it safely.
+
+With PowerShell 5.0, this object-oriented notion of a *class* was introduced into the PowerShell language with the intention of enabling PowerShell users to create objects for consumption by .Net Code. While conceptually these classes are analogs of the same classes delivered through the `class` keyword in the aforementioned OO languages, the key scenario for PowerShell classes was to enable the development of PowerShell DSC resources. Given this, it's understandable that the user experience of PowerShell's class feature is closer to that of PowerShell's pre-existing .Net interoperability, particularly with the syntax of method invocation, rather than providing an exerience for classes more in line with PowerShell's command-line / pipeline-focused approach.
+
+Here's an example of usage of a `class` in PowerShell -- note that it requires the use of .Net calling and procedure definition syntax -- parentheses required, commas between parameters, explicit `return` statement for non-`void` methods, and explicit return type declaration for non-`void` methods:
+
+```powershell
+class ShellInfo {
+    $username
+    $computername
+    ShellInfo($username, $computername) {
+        $this.username = $username
+        $this.computername = $computername
+    }
+    [string] GetCustomShellPrompt($prefix, $promptseparator) {
+        return "$prefix $($this.username)@$($this.computername) $promptseparator"
+    }
+}
+
+function prompt {
+    $shellInfo = [ShellInfo]::new("user1", "computer0")
+    $shellInfo.GetCustomShellPrompt("%", "-> ")
+}
+
+```
+
+As opposed to this, which uses the normal PowerShell calling and declaration syntax: no parentheses needed to pass parameters to a function, no punctuation just spaces between parameters, implicit return via simply expressing a value, and no need to specify a return type for a method, regardless whether it does or does not end up returning a value:
+
+```powershell
+function NewShellInfo($username, $computername) {
+    @{username=$username;computername=$computername}
+}
+
+function GetCustomShellPrompt($shellinfo, $prefix, $promptseparator) {
+    $username = $shellInfo['username']
+    $computername = $shellInfo['computername']
+    "$prefix $($username)@$($computername) $promptseparator"
+}
+
+function prompt {
+    $shellInfo = NewShellInfo "user1" "computer0"
+    GetCustomShellPrompt $shellInfo "%" "-> "
+}
+```
+With the addition of `class`, PowerShell scripts may not include *both* of these styles of code. This has drawbacks:
+
+* Most scripts will be forced to "mix" both styles, which results in some confusion when reading the scripts ("why is this function being called with parentheses and this one not -- ah, it's a class method, not a function")
+* The mixing can cause errors during development such as accidentally using parentheses with PowerShell functions after defining several class methods. This results in errors known quite well to PowerShell users where your function behaves strangely, you debug it to realize it's getting passed an array even though you are passing a different type, and after looking at the call site for a long time and debugging other parts of the code to determine what parameters you are actually passing, you realize you need to remove the parentheses and commas and pass parameters the way PowerShell expects.
+* When you use class methods, you forego useful and productive PowerShell capabilities like passing parameters by name or through the pipeline
+
+In short, any PowerShell code that incorporates classes as presented by the language reference will be a mash of programming paradigms. The question arises: what would PowerShell's `class` feature look like if it were compatible with the existing PowerShell function call model? Is there a way to make classes, or something like them, support a more `function`-like model?
+
+#### Making `class` safe for PowerShell
+
+Here are a few ideas around what a more `function`-y `class` would look like:
+
+1. You could define methods, including constructors, using PowerShell function declaration syntax and calling conventions
+2. You could invoke methods, including those used to instantiate new class instances, using all Powershell calling conventions and associated syntax
+3. Return value type specification would be completely optional for class methods -- methods could return an object of any type, or none at all, regardless whether a return type is specified, just as with PowerShell functions
+4. Class methods could specify return values just like functions, i.e. without using the `return` keyword or equivalent.
+5. You could define public class fields (i.e. data members) and default values as easily as they are declared in PowerShell's `class` syntax, i.e. simply by listing the field names and optionally assigning a default value
+6. You could access public class fields with a simple `.` operator as in most object-based languages including PowerShell's own implementation of `class`.
+7. Class methods could refer to their own fields using something like a `this` object as in many object-based languages to distinguish between the object's own state vs. other variables
+8. Association of methods with a class could be done without relying on naming conventions and would actually be enforced by PowerShell
+9. Method calls on an object could be invoked with a `.` syntax between the object and method just as with data field access
+
+
+With that, here's an example of a syntax that satisfies these requirements:
+
+```powershell
+func_class ShellInfo {
+    $username
+    $computername
+
+    ShellInfo($username, $computername) {
+        $this.username = $username
+        $this.computername = $computername
+    }
+
+    function GetCustomShellPrompt($prefix, $promptseparator) {
+        "$prefix $($this.username)@$($this.computername) $promptseparator"
+    }
+}
+
+function prompt {
+    $shellInfo = ShellInfo __new "user1" "computer0"
+    $shellInfo.GetCustomShellPrompt "%" "-> "
+}
+```
+
+Here the syntax for declaring the method `GetCustomShellPrompt` is simply function syntax -- in fact, the `function` keyword is used to declare it. And calling the method `GetCustomShellPrompt` requires parentheses or commas for the parameter list -- very much the PowerShell way. Creating the class seems to involve a method called `__new`, called in a similar PowerShell fashion.
+
+Note that this proposal includes some elements out of necessity, i.e. this syntax can be implemented without changing PowerShell in any way, at the expense of some oddities in the syntax that implement the requirements from within the existing PowerShell language:
+
+```powershell
+# Dot-source a helper script at the start of any file in which you want to define a class with this syntax
+. "$psscriptroot/define-class.ps1" 
+
+function ShellInfo($method = $null) {
+    class ShellInfo {
+        $username
+        $computername
+        ShellInfo($username, $computername) {
+            $this.username = $username
+            $this.computername = $computername
+        }
+    }
+
+    function GetCustomShellPrompt($_this, $prefix, $promptseparator) {
+        "$prefix $($_this.username)@$($_this.computername) $promptseparator"
+    }
+
+    . $define_class @args
+}
+
+function prompt {
+    $shellInfo = ShellInfo __new "user1" "computer0"
+    ShellInfo GetCustomShellPrompt $shellInfo "%" "-> "
+}
+```
+
+In many ways, this approach, which we'll describe in a more generalized form later, does cover items 1-8. A key strength is it the very clean syntax for defining methods as PowerShell functions, and then being able to call those methods using PowerShell function call syntax.
+
+However, other aspects of the approach are not without a few compromise and some less than elegant artifacts:
+
+* The beginning of the declaration requires a `function`, not a class, that defines a function with the same name as the class. There is no obvious reason why this is needed.
+* The function takes an argument `$method = $null` -- why? There is no reference to `$method` anywhere in the function or class definition. There may be a way for us to fix this part at least though.
+* The function calling syntax, rather than `object.method [argument1 [argument2]...]` requires the class name in addition to the object and method.
+* Most glaringly, the definition ends with the strange incantation `. $define_class @args`. This artifact was required to implement the "magic" that makes the calling convention, as awkward as it is, possible given the mostly readable definition. See the appendix for the magic behind `$define_class`.
+
+There may be ways to clean this up purely by including some PowerShell code, particuarly the strange `$method = $null` parameter. Given the limitations, it is worth considering alternatives.
+
+### Alternative class approaches
+
+Stepping back, it is worth considering the question: given that PowerShell is a language based on the object-oriented CLR, is there a way to surface its object-oriented foundations in a way that gives us class semantics?
+
+This query becomes more concrete when considering PowerShell's extended type system, surfaced through the .Net types `PSObject` and `PSCustomObject`. These object types allow PowerShell to express the input and output of commands as structured objects, one of the key motivators for the introduction of the PowerShell scripting language as an alternative to popular powerful scripting languages like those of the various Unix shells. The PowerShell extended type system is an object-oriented one, and includes support for the concepts of fields (fields), getters / setters, and methods. Can we use this capability to provide a clean user experience for defining and using objects?
+
+Discussions such as [this one](https://kevinmarquette.github.io/2016-10-28-powershell-everything-you-wanted-to-know-about-pscustomobject/) regarding the type system indicate some promise. It turns out that through `[PSCustomObject]` it is possible to define types that support the `.` syntax for accessing fields, as well as providing type safety. The initialization of such objects is possible by using PowerShell hash tables, and while not specific in syntax to object creation and requiring some punctuation, it is at least a familiar syntax and concept to PowerShell users.
+
+A direction, then, might be to combine the strengths of our current proposal, i.e. namely association of PowerShell functions with an object as its methods, with PowerShell's native concept of object in `PSCustomObject` to provide fields and type enforcement. Such a combination could minimize the contrivances required to balance syntax and functionality of object definition and usage.
+
+## Appendix -- implementing the new syntax
+The new class syntax described earlier was achieved in the following fashion:
+
+* In an external PowerShell script file, we define a variable `$define_class` that is actually a script block designed to be dot-sourced inside of a PowerShell function, just as in our sample earlier.
+* This external file is itself dot-sourced the beginning of any file (i.e. using something like the line `. "$psscriptroot/define-class.ps1"`).
+
+After this, placing the line `. $define_class @args` at the end of the function used to define the class provides the syntax and semantics for object invocation.
+
+Below is a snapshot of the contents of a `$define-class.ps1` implementation. Note that as a workaround to issues where PowerShell apparently redefines classes defined by the `class` keyword (if you inspect the `typeHandle` property of the .Net type for a type created through PowerShell's `class` keyword, you'll find that a repeat of the same definition will create a separate .Net type with a different `typeHandle` value, and also that `-eq` between such types will be false), extra care is given to keep track of the originally invoked definition of the class:
+
+```powershell
+# See the LICENSE information in this repository for licensing
+$existing_classes = @{}
+$define_class = {
+    function __new {
+        new-object $thisTypeName -argumentlist $args
+    }
+
+    $thisType = $null
+    $thisTypeName = (get-pscallstack)[1].command
+    $existingType = $existing_classes[$thisTypeName]
+    if ($existingType -eq $null ) {
+        $thisType = invoke-expression "[$thisTypeName]"
+        $existing_classes[$thisTypeName] = $thisType
+    } else {
+        $thisType = $existingType
+    }
+
+    if ($method -eq $null) {
+        if ($args.length -gt 0) {
+            throw [ArgumentException]::new("Arguments were specified without a method")
+        }
+        $thisType
+    } else {
+        if ($args.length -gt 0 -and $method -ne '__new' -and $args[0].Gettype().name -ne $thisType.name) {
+            throw [InvalidCastException]::new("Mismatch type '$($args[0].gettype())' supplied when type '$thisType' was required`n$(get-pscallstack)")
+        }
+        $scriptblock = (get-item (join-path -path "function:" -child $method)).scriptblock
+        $result = try {
+            $scriptblock.invokereturnasis($args)
+        } catch {
+            get-pscallstack | out-host
+            throw
+        }
+        $result
+    }
+}
+```
+

--- a/src/lib/stdlib/define-class.ps1
+++ b/src/lib/stdlib/define-class.ps1
@@ -34,7 +34,7 @@ $define_class = {
         $thisType
     } else {
         if ($args.length -gt 0 -and $method -ne 'new' -and $args[0].Gettype().name -ne $thisType.name) {
-            throw [InvalidCastException]::new("Mismatch type '$($args[0].gettype())' supplied when type '$thisType' was required")
+            throw [InvalidCastException]::new("Mismatch type '$($args[0].gettype())' supplied when type '$thisType' was required`n$(get-pscallstack)")
         }
         $scriptblock = (get-item (join-path -path "function:" -child $method)).scriptblock
         $result = try {

--- a/src/lib/stdlib/define-class.ps1
+++ b/src/lib/stdlib/define-class.ps1
@@ -13,7 +13,7 @@
 # limitations under the License.
 $existing_classes = @{}
 $define_class = {
-    function new {
+    function __new {
         new-object $thisTypeName -argumentlist $args
     }
 
@@ -33,7 +33,7 @@ $define_class = {
         }
         $thisType
     } else {
-        if ($args.length -gt 0 -and $method -ne 'new' -and $args[0].Gettype().name -ne $thisType.name) {
+        if ($args.length -gt 0 -and $method -ne '__new' -and $args[0].Gettype().name -ne $thisType.name) {
             throw [InvalidCastException]::new("Mismatch type '$($args[0].gettype())' supplied when type '$thisType' was required`n$(get-pscallstack)")
         }
         $scriptblock = (get-item (join-path -path "function:" -child $method)).scriptblock

--- a/src/lib/stdlib/define-class.ps1
+++ b/src/lib/stdlib/define-class.ps1
@@ -1,0 +1,48 @@
+# Copyright 2017, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+$existing_classes = @{}
+$define_class = {
+    function new {
+        new-object $thisTypeName -argumentlist $args
+    }
+
+    $thisType = $null
+    $thisTypeName = (get-pscallstack)[1].command
+    $existingType = $existing_classes[$thisTypeName]
+    if ($existingType -eq $null ) {
+        $thisType = invoke-expression "[$thisTypeName]"
+        $existing_classes[$thisTypeName] = $thisType
+    } else {
+        $thisType = $existingType
+    }
+
+    if ($method -eq $null) {
+        if ($args.length -gt 0) {
+            throw [ArgumentException]::new("Arguments were specified without a method")
+        }
+        $thisType
+    } else {
+        if ($args.length -gt 0 -and $method -ne 'new' -and $args[0].Gettype().name -ne $thisType.name) {
+            throw [InvalidCastException]::new("Mismatch type '$($args[0].gettype())' supplied when type '$thisType' was required")
+        }
+        $scriptblock = (get-item (join-path -path "function:" -child $method)).scriptblock
+        $result = try {
+            $scriptblock.invokereturnasis($args)
+        } catch {
+            get-pscallstack | out-host
+            throw
+        }
+        $result
+    }
+}

--- a/src/lib/stdlib/enable-include.ps1
+++ b/src/lib/stdlib/enable-include.ps1
@@ -17,11 +17,11 @@ $processedNone = $false
 while (-not $processedNone ) {
     $processedCount = 0
     $files = @()
-    $global:includes.keys | foreach { $files += $_ }
+    $includes.keys | foreach { $files += $_ }
     $files | foreach {
         if ( -not $includes[$_] ) {
             . $_
-            $global:includes[$_] = $true
+            $includes[$_] = $true
             $processedCount += 1
         }
     }

--- a/src/lib/stdlib/include.ps1
+++ b/src/lib/stdlib/include.ps1
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-$global:includes = @{}
-$global:included = @{}
+$includes = @{}
+$included = @{}
 
 function ValidateIncludePath($includePath) {
     if ( $includePath.StartsWith("/") -or $includePath.StartsWith("\\") ) {
@@ -33,12 +33,12 @@ function include-source($appRelativePath)
     ValidateIncludePath($appRelativePath)
     $relativePath = "$($appRelativePath).ps1"
     $relativeNormal = $relativePath.ToLower()
-    $fullPath = (join-path $global:ApplicationRoot $relativePath | get-item).Fullname
+    $fullPath = (join-path $ApplicationRoot $relativePath | get-item).Fullname
     $canonical = $fullPath.ToLower()
-    if ( $global:included[$canonical] -eq $null )
+    if ( $included[$canonical] -eq $null )
     {
-        $global:included[$canonical] = @($global:ApplicationRoot, $relativeNormal)
-        $global:includes[$canonical] = $false
+        $included[$canonical] = @($ApplicationRoot, $relativeNormal)
+        $includes[$canonical] = $false
     }
 }
 

--- a/src/lib/stdlib/start-app.ps1
+++ b/src/lib/stdlib/start-app.ps1
@@ -14,6 +14,6 @@
 
 . "$psscriptroot/enable-stdlib.ps1"
 
-include-source "src/app/$global:applicationEntryScriptName"
+include-source "src/app/$script:applicationEntryScriptName"
 
-. "$($global:ApplicationRoot)/src/lib/stdlib/enable-include.ps1"
+. "$($script:ApplicationRoot)/src/lib/stdlib/enable-include.ps1"

--- a/src/lib/stdlib/std.ps1
+++ b/src/lib/stdlib/std.ps1
@@ -32,5 +32,6 @@ function script:ApplicationRoot {
 }
 
 . (join-path $psscriptroot include.ps1)
+. (join-path $psscriptroot 'define-class.ps1')
 
 $script:IsStdlibInitialized = $true

--- a/src/lib/stdlib/std.ps1
+++ b/src/lib/stdlib/std.ps1
@@ -15,7 +15,7 @@
 set-strictmode -version 2
 
 $alreadyInitialized = try {
-    get-variable -scope $script:IsStdLibInitialized
+    get-variable -scope script IsStdLibInitialized >* out-null
     $true
 } catch {
     $false
@@ -25,10 +25,10 @@ if ($alreadyInitialized) {
     throw "This script file must only be sourced once from the entry script."
 }
 
-$global:ApplicationRoot = (get-item "$psscriptRoot/../../..").fullname
+$ApplicationRoot = (get-item "$psscriptRoot/../../..").fullname
 
 function script:ApplicationRoot {
-    $global:ApplicationRoot
+    $ApplicationRoot
 }
 
 . (join-path $psscriptroot include.ps1)


### PR DESCRIPTION
The initial implementation attempted to make use of PowerShell classes for all of the reasons that classes are considered "good" in other languages -- encouragement of simple, testable, loosely-coupled components, discouraging hidden or unnecessary dependencies, increasing the opportunity for code re-use, etc. Unfortunately, PowerShell classes really weren't intended to enhance PowerShell in this way, and are mostly about interoperability with other .Net-based languages / systems such as C# and PowerShell DSC. Due to this, the resulting code was a confusing mix of two paradigms, i.e. PowerShell's functional command-line paradigm and C#'s object-based paradigm, along with their separate but easily-confused syntaxes and the need to translate between the two paradigms at times.

To avoid this complexity and confusion, we introduce a stripped-down usage of PowerShell classes along with some syntactic sugar to make it easy to declare them. This improves the code in a lot of ways, i.e. there is essentially only one calling paradigm, the PowerShell functional CLI. However, other artifacts of the implementation are still an issue, so there is room for improvement.