### PR TITLE
Fix regressions in get-graphschema, get-graphversion and invoke-graphrequest

### DIFF
--- a/PoshGraph.psd1
+++ b/PoshGraph.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.10.5'
+ModuleVersion = '0.10.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Fix token refresh
 * Refactor into posh-graph core sdk and poshgraph ux
 * Clean up parse methods in GraphUtilities
 * Investigate console.writeline background thread

--- a/src/cmdlets/Get-GraphSchema.ps1
+++ b/src/cmdlets/Get-GraphSchema.ps1
@@ -59,8 +59,7 @@ function Get-GraphSchema {
     $graphConnection = if ( $connection ) {
         $connection
     } else {
-        $currentContext = 'GraphContext' |::> GetConnection $null $null $cloud 'User.Read'
-        $currentContext.Connection
+        'GraphContext' |::> GetConnection $null $null $cloud 'User.Read'
     }
 
     $relativeBase = 'schemas'
@@ -84,7 +83,7 @@ function Get-GraphSchema {
             $sourceApiVersion = if ( $ApiVersion -ne $null -and $ApiVersion -ne '' ) {
                 $apiVersion
             } else {
-                $::.GraphContext |=> GetVersion
+                ($::.GraphContext |=> GetCurrent).version
             }
             get-graphversion -Connection $graphConnection -version $sourceApiVersion
         }

--- a/src/cmdlets/Get-GraphVersion.ps1
+++ b/src/cmdlets/Get-GraphVersion.ps1
@@ -41,8 +41,7 @@ function Get-GraphVersion {
     $graphConnection = if ( $connection ) {
         $connection
     } else {
-        $currentContext = 'GraphContext' |::> GetConnection $null $null $cloud 'User.Read'
-        $currentContext.Connection
+        'GraphContext' |::> GetConnection $null $null $cloud 'User.Read'
     }
 
     $relativeBase = 'versions'

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -176,7 +176,10 @@ function Invoke-GraphRequest {
             throw "The version '$($info.Graphversion)' and connection endpoint '$($specificcontext.Connection.GraphEndpoint.Graph)' is not compatible with the uri '$RelativeUri'"
         }
         $info
-    } else {
+    } elseif ( $graphType -ne ([GraphType]::AADGraph) ) {
+        # We only parse URI's relative to context for MS Graph -- AADGraph
+        # context is not tracked, so don't try to construct a context relative
+        # AAD Graph path
         $info = $::.GraphUtilities |=> ParseGraphRelativeLocation $RelativeUri[0]
         @{
             GraphRelativeUri = $info.GraphRelativeUri


### PR DESCRIPTION
### Description

Fixes regressions in `Get-GraphSchema`, `Get-GraphVersion`, and the AADGraph functionality of `Invoke-GraphRequest`.

### Dependency changes

No dependency changes

### Implementation notes

Fix for `Get-GraphSchema` and `Get-GraphVersion` was to fix a fairly obvious defect where we were getting a connection object and treating it as a context and then trying to get a connection -- simply wrong. We should have just taken the original connection object and returned it. For `Invoke-GraphRequest` breaking for `-aadgraph` option, the fix was to not try to find a context for the uri when aad graph option is set -- we don't support context for aad graph. The bug was causing us to take the version from the (msgraph) context, which was v1.0, and the aad graph version *must* be 1.6. With the fix, the code path where we choose version 1.6 was restored and everything works.
### Linked issues

### Checklist

- [ ] All project tests pass successfully

