### PR TITLE
0.11.1 release, new scriptclass and poshgraph-sdk dependencies to fix publish-module …

### DIFF
--- a/PoshGraph.psd1
+++ b/PoshGraph.psd1
@@ -67,8 +67,8 @@ ScriptsToProcess = @('./src/graph.ps1')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='poshgraph-sdk';ModuleVersion='0.1.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
-    @{ModuleName='scriptclass';ModuleVersion='0.13.6';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
+    @{ModuleName='poshgraph-sdk';ModuleVersion='0.1.2';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='scriptclass';ModuleVersion='0.13.7';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.

--- a/poshgraph.nuspec
+++ b/poshgraph.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="poshgraph-sdk" version="0.1.1" />
+      <dependency id="poshgraph-sdk" version="0.1.2" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
…regression caused by scriptclass 0.13.6

### Description

Removes preview tag and fixes a regression exposed by new versions of PowerShellGet and a latent bug in scriptclass 0.13.6.

### Dependency changes

Update to scriptclass 0.13.7 from 0.13.6.

- [ ] All project tests pass successfully
