### PR TITLE
Update docs to reflect repository rename to AutoGraphPS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,10 +20,10 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. Windows 10 RS 4]
- - PoshGraph Version [e.g. 0.9.2]
+ - AutoGraphPS module Version [e.g. 0.14.3]
 
 **Logs -- please attach the following data for failures executing a command
- - Output of the PoshGraph command using the `-verbose` option
+ - Output of the AutoGraphPS command using the `-verbose` option
 
 **Additional context**
 Add any other context about the problem here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in **AutoGraphPS**. This document describes the proc
 
 ## What may I contribute?
 
-Contributions to AutoGraphPS may come in the form of source code, i.e. features and defect fixes, as well as [bug reports and feature requests](https://github.com/adamedx/poshgraph/issues/new/choose).
+Contributions to AutoGraphPS may come in the form of source code, i.e. features and defect fixes, as well as [bug reports and feature requests](https://github.com/adamedx/autographps/issues/new/choose).
 
 Note that all source contributions **MUST** conform to the project's [LICENSE](LICENSE.md) -- any submission in violation of the LICENSE will not be accepted.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 ## In general
 
-**[AutoGraphPS](https://github.com/adamedx/poshgraph)** is a client-side tool for interacting with the [Microsoft Graph API](https://graph.microsoft.io). **AutoGraphPS** does not maintain any store of data involving your usage of the tool.
+**[AutoGraphPS](https://github.com/adamedx/autographps)** is a client-side tool for interacting with the [Microsoft Graph API](https://graph.microsoft.io). **AutoGraphPS** does not maintain any store of data involving your usage of the tool.
 
 ## Data collection
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 AutoGraphPS
 ===========
 
-<img src="https://raw.githubusercontent.com/adamedx/poshgraph/master/assets/PoshGraphIcon.png" width="100">
+<img src="https://raw.githubusercontent.com/adamedx/autographps/master/assets/PoshGraphIcon.png" width="100">
 
 ----
 
 * [Overview](#Overview)
 * [Installation](#Installation)
-* [Using AutoGraphPS](#using-poshgraph)
+* [Using AutoGraphPS](#using-autographps)
 * [Common uses](#common-uses)
 * [Command inventory](#command-inventory)
 * [Developer installation from source](#developer-installation-from-source)
@@ -25,7 +25,7 @@ AutoGraphPS
 * SharePoint
 * And many more!
 
-If you're an application developer, DevOps engineer, system administrator, or enthusiast power user, AutoGraphPS was made just for you. If you're building Graph-based applications in PowerShell, consider using the lighter-weight [AutoGraphPS-SDK](https://github.com/adamedx/poshgraph-sdk) which contains a smaller kernel of Graph cmdlets focused on automation and omitting the UX affordances found in this module.
+If you're an application developer, DevOps engineer, system administrator, or enthusiast power user, AutoGraphPS was made just for you. If you're building Graph-based applications in PowerShell, consider using the lighter-weight [AutoGraphPS-SDK](https://github.com/adamedx/autographps-sdk) which contains a smaller kernel of Graph cmdlets focused on automation and omitting the UX affordances found in this module.
 
 The project is in the earliest stages of development and almost but not quite yet ready for collaborators.
 
@@ -219,8 +219,8 @@ If you'd like a behind the scenes look at the implementation of AutoGraphPS, tak
 For developers contributing to AutoGraphPS or those who wish to test out pre-release features that have not yet been published to PowerShell Gallery, run the following PowerShell commands to clone the repository and then build and install the module on your local system:
 
 ```powershell
-git clone https://github.com/adamedx/poshgraph
-cd poshgraph
+git clone https://github.com/adamedx/autographps
+cd autographps
 .\build\install-fromsource.ps1
 ```
 
@@ -233,9 +233,9 @@ See the [Build README](build/README.md) for instructions on building and testing
 ## Quickstart
 The Quickstart is a way to try out AutoGraphPS without installing the AutoGraphPS module. In the future it will feature an interactive tutorial. Additionally, it is useful for developers to quickly test out changes without modifying the state of the operating system or user profile. Just follow these steps on your workstation to start **AutoGraphPS**:
 
-* [Download](https://github.com/adamedx/poshgrap/archive/master.zip) and extract the zip file for this repository **OR** clone it with the following command:
+* [Download](https://github.com/adamedx/autographps/archive/master.zip) and extract the zip file for this repository **OR** clone it with the following command:
 
-  `git clone https://github.com/adamedx/poshgraph`
+  `git clone https://github.com/adamedx/autographps`
 
 * Within a **PowerShell** terminal, `cd` to the extracted or cloned directory
 * Execute the command for **QuickStart**:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# ROADMAP for PoshGraph
+# ROADMAP for AutoGraphPS
 
 ## To-do items -- prioritized
 

--- a/docs/MOTIVATION.md
+++ b/docs/MOTIVATION.md
@@ -1,9 +1,9 @@
-Why PoshGraph?
-==============
+Why AutoGraphPS (fka PoshGraph)?
+================================
 
 Many developers' first experience of the The Microsoft Graph is mediated through Graph Explorer. This web-based tool makes the abstract Graph API into something tangible to be navigated and manipulated as one would casually use a web browser.
 
-Missing from Graph Explorer, however, is a facility for automation. That's the need filled by this project. PoshGraph is the programmable Graph Explorer designed for developers and system administrators. It's designed for both exploration AND automation.
+Missing from Graph Explorer, however, is a facility for automation. That's the need filled by this project. AutoGraphPS is the programmable Graph Explorer designed for developers and system administrators. It's designed for both exploration AND automation.
 
 ## Developer wish list
 
@@ -23,7 +23,7 @@ Of the small number of tools focused on the Graph itself, there are none that su
   * Elastic -- requires no updates to take advantage of new APIs and services exposed in the Graph
   * Delightful -- your wildest ideas about the Graph made real with little to no friction
 
-PoshGraph is a single app that provides "all of the above."
+AutoGraphPS is a single app that provides "all of the above."
 
 ## Goals
 
@@ -47,17 +47,17 @@ However, the case for PowerShell goes beyond just fitting in. PowerShell has the
 * Scriptability / Programmability: PowerShell cmdlets are not just usable in adhoc cases, they may be used the same way from within scripts, i.e. programs / applications / automation, just as they are used interactively. Users can then create simple scripts by "replaying" commands entered interactively to test a scenario. Those scripts will be robust because PowerShell cmdlets take in and return return well-defined structured types (i.e. "objects") just as functions / procedures / methods do in any modern programming language. PowerShell scripts then can scale to the level of sophistication offered by other object-based scripting languages enabling full-blown applications and system libraries.
 * Intuitiveness: Integrating with PowerShell's existing interfaces reveals omissions or inconsistencies in the intial conception of a CLI-UX; building on PowerShell forces implementors to reckon with those difficulties, ultimately resulting in an even simpler and more intuitive interface for users.
 
-PowerShell through its conventions and CLI-feature support enforces a consistent, simple, scalable user interface for the CLI. By building with PowerShell, PoshGraph inherits those same productivity and delight-enhancing capabilities.
+PowerShell through its conventions and CLI-feature support enforces a consistent, simple, scalable user interface for the CLI. By building with PowerShell, AutoGraphPS inherits those same productivity and delight-enhancing capabilities.
 
 ### Traverse it like the file system
 
 For many command-line users and developers, a recurring structural metaphor is that of the hierarchical file system. It [pervades the Unix architecture and experience](https://en.wikipedia.org/wiki/Everything_is_a_file), and even on Windows, PowerShell surfaces ["drive providers"](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_providers?view=powershell-6) as a UX to abstract not just the file system, but also Windows-specific components such as the registry, certificate store, system environment variables, and even PowerShell's variables, functions, and aliases.
 
-PoshGraph's cmdlets `Get-GraphChildItem`, `Get-GraphLocation`, and `Get-GraphLocation` provide a similar metaphor for the Graph, which, like a hierarchical file system, has a single root node from which all other nodes are reachable. Excepting the presence of the word "graph", the `cmdlets` names are the same as those of PowerShell's generic commands for traversing any provider, including the file system.
+AutoGraphPS's cmdlets `Get-GraphChildItem`, `Get-GraphLocation`, and `Get-GraphLocation` provide a similar metaphor for the Graph, which, like a hierarchical file system, has a single root node from which all other nodes are reachable. Excepting the presence of the word "graph", the `cmdlets` names are the same as those of PowerShell's generic commands for traversing any provider, including the file system.
 
-While PoshGraph's initial implementation does not include a PowerShell drive provider, the cmdlets emulate such behavior, allowing you to get and set your location in the hierarchy as in the `cd` command in many shells, and list the contents of the current location as in the `ls` or `dir` commands. More importantly, the notion of current and containing location allows you to omit long absolute paths for references to elements of the Graph when you are invoking the cmdlets from the shell, saving time and conserving cognitive space.
+While AutoGraphPS's initial implementation does not include a PowerShell drive provider, the cmdlets emulate such behavior, allowing you to get and set your location in the hierarchy as in the `cd` command in many shells, and list the contents of the current location as in the `ls` or `dir` commands. More importantly, the notion of current and containing location allows you to omit long absolute paths for references to elements of the Graph when you are invoking the cmdlets from the shell, saving time and conserving cognitive space.
 
-The effect is that just as one might explore the contents and capabilities of a file system in *nix, Windows, and other systems to discover capabilities and structure, the same can be done with PoshGraph, allowing users to learn where certain Graph functionality resides and how to use it.
+The effect is that just as one might explore the contents and capabilities of a file system in *nix, Windows, and other systems to discover capabilities and structure, the same can be done with AutoGraphPS, allowing users to learn where certain Graph functionality resides and how to use it.
 
 ### Keep it generic -- give it a REST
 
@@ -67,75 +67,75 @@ The advantage to that approach is the ability to provide deep customization, inc
 
 That customization comes with a serious drawback: *Every time new features or capabilities are added to the Graph, the cmdlets must be updated to reflect it.*
 
-PoshGraph uses a different approach: **Let PoshGraph act as a PowerShell layer on top of the Graph REST API layer.** This takes advantage of the fact that Graph is already a generic, and hopefully well-designed API based on a standard set of object types in the [Entity Data Model (EDM) metadata](https://developer.microsoft.com/en-us/graph/docs/concepts/traverse_the_graph). That data model is really what drives Graph, and it is continuously updated to reflect the new features added to services exposed by the Graph. In theory such an approach should be reasonable since if the Graph API itself is a truly usable API, making that API directly accessible through PowerShell should also result in similarly usable CLI experience.
+AutoGraphPS uses a different approach: **Let AutoGraphPS act as a PowerShell layer on top of the Graph REST API layer.** This takes advantage of the fact that Graph is already a generic, and hopefully well-designed API based on a standard set of object types in the [Entity Data Model (EDM) metadata](https://developer.microsoft.com/en-us/graph/docs/concepts/traverse_the_graph). That data model is really what drives Graph, and it is continuously updated to reflect the new features added to services exposed by the Graph. In theory such an approach should be reasonable since if the Graph API itself is a truly usable API, making that API directly accessible through PowerShell should also result in similarly usable CLI experience.
 
-PoshGraph's design is focused then on the following three things that apply to the entire Graph:
+AutoGraphPS's design is focused then on the following three things that apply to the entire Graph:
 
-* Authentication: PoshGraph implements UX concepts for easy authentication and authorization via the OAuth2 protocol as required Microsoft Graph
-* REST: PoshGraph automates REST conventions through consistent URI UX, handling of standard REST error statuses, and invocation of the appropriate REST methods (`GET`, `PUT`, `POST`, etc.)
-* [Entity Data Model (EDM)](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/entity-data-model): PoshGraph consumes the [EDM metadata exposed by Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/traverse_the_graph) to surface types and a sense of location, and thus capabilities, to the user
+* Authentication: AutoGraphPS implements UX concepts for easy authentication and authorization via the OAuth2 protocol as required Microsoft Graph
+* REST: AutoGraphPS automates REST conventions through consistent URI UX, handling of standard REST error statuses, and invocation of the appropriate REST methods (`GET`, `PUT`, `POST`, etc.)
+* [Entity Data Model (EDM)](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/entity-data-model): AutoGraphPS consumes the [EDM metadata exposed by Graph](https://developer.microsoft.com/en-us/graph/docs/concepts/traverse_the_graph) to surface types and a sense of location, and thus capabilities, to the user
 
-All of these design elements are universal throughout the Graph and are not specific to AAD, files, messaging, or any other part of the Graph. The advantages of aligning PoshGraph toward them are:
-* No changes are needed to PoshGraph source code as new service features are enabled. Users do not need to continuously update their PoshGraph installations to get access to new Graph functionality.
-* The PoshGraph code base is simpler as domain-specific code can be omitted
-* Fewer poor cmdlet design choices are likely to be made in PoshGraph as domain-specific design is left to the Graph layer -- PoshGraph merely reflects what is in the Graph
-* Domain-specific documentation developed for the Graph API itself can easily be consumed when using PoshGraph -- the URI's specified in the documentation along with REST methods are mapped 1-1 to URI's specified to PoshGraph cmdlets that themselves correspond to the appropriate REST methods.
+All of these design elements are universal throughout the Graph and are not specific to AAD, files, messaging, or any other part of the Graph. The advantages of aligning AutoGraphPS toward them are:
+* No changes are needed to AutoGraphPS source code as new service features are enabled. Users do not need to continuously update their AutoGraphPS installations to get access to new Graph functionality.
+* The AutoGraphPS code base is simpler as domain-specific code can be omitted
+* Fewer poor cmdlet design choices are likely to be made in AutoGraphPS as domain-specific design is left to the Graph layer -- AutoGraphPS merely reflects what is in the Graph
+* Domain-specific documentation developed for the Graph API itself can easily be consumed when using AutoGraphPS -- the URI's specified in the documentation along with REST methods are mapped 1-1 to URI's specified to AutoGraphPS cmdlets that themselves correspond to the appropriate REST methods.
 
-This elasticity comes with a price, that of the loss of domain-specific optimization. The philosophy is that this tradeoff is worth it in the common case where there is value in avoiding frequent updates to PoshGraph to keep up with changes to the Graph API, and also in PoshGraph inheriting the Graph API's scalability of usage from simple to complex scenarios.
+This elasticity comes with a price, that of the loss of domain-specific optimization. The philosophy is that this tradeoff is worth it in the common case where there is value in avoiding frequent updates to AutoGraphPS to keep up with changes to the Graph API, and also in AutoGraphPS inheriting the Graph API's scalability of usage from simple to complex scenarios.
 
 ### Re-imagine Graph's rough spots
 
 One of the most difficult aspects of using the Graph is authentication. While in theory standardization on OAuth2 should allow consumers of the Graph to take advantage of standard OAuth2 libraries, no such libraries exist explicitly for PowerShell itself. Even in C# where PowerShell can interoperate with libraries quite efficiently, there has been confusion on which of two major libraries to use, both of which support scenarios that the other does not. The result is that in languages with an OAuth2 SDK, several lines of code requiring knoweledge of specific authentication endpoints and "application identity" configurations, most notably the pre-registered application identity and redirection URIs, must be invoked.
 
-PoshGraph aims to make authentication as easy as it is when using Graph Explorer -- invoke PoshGraph and provide credentials, and perhaps specify authorization scopes. No knowledge of the AAD application model, redirection URIs, application IDs, or login endpoints is required. A standalone cmdlet is even given to obtain authorization tokens that can be used with REST tools other than PoshGraph since those tools have no simple way of getting a Graph-specific token.
+AutoGraphPS aims to make authentication as easy as it is when using Graph Explorer -- invoke AutoGraphPS and provide credentials, and perhaps specify authorization scopes. No knowledge of the AAD application model, redirection URIs, application IDs, or login endpoints is required. A standalone cmdlet is even given to obtain authorization tokens that can be used with REST tools other than AutoGraphPS since those tools have no simple way of getting a Graph-specific token.
 
 Another area of friction is that of the input and output format for interacting with the Graph. Graph uses JSON, which is well-supported by many tools and somewhat human readable. However, with the kinds of nested structures used by Graph, it is very easy to incorrectly interpret or construct Graph JSON.
 
-To get around human comprehension of JSON, PoshGraph by default uses PowerShell objects which are converted between PowerShell objects and JSON through PowerShell's JSON serialization libraries. The result is that no careful JSON construction is required -- users can access Graph objects through PoshGraph as browsable objects as they would in native PowerShell, with C# via debuggers, or with dynamic languages including Javascript itself or Ruby, Python, etc.
+To get around human comprehension of JSON, AutoGraphPS by default uses PowerShell objects which are converted between PowerShell objects and JSON through PowerShell's JSON serialization libraries. The result is that no careful JSON construction is required -- users can access Graph objects through AutoGraphPS as browsable objects as they would in native PowerShell, with C# via debuggers, or with dynamic languages including Javascript itself or Ruby, Python, etc.
 
 ### Don't RTFM
 
-PoshGraph attempts to prompt users with solutions when certain kinds of errors are encountered. The goal is for users to be able to try scenarios that they think should work and get feedback from PoshGraph itself to correct their mistakes, rather than requiring study ahead of time or extensive web searches to understand workarounds for errors.
+AutoGraphPS attempts to prompt users with solutions when certain kinds of errors are encountered. The goal is for users to be able to try scenarios that they think should work and get feedback from AutoGraphPS itself to correct their mistakes, rather than requiring study ahead of time or extensive web searches to understand workarounds for errors.
 
-In general, PoshGraph also aims to take away the need to look up documentaiton, using much the same approach as Graph Explorer: use the Graph's EDM metadata to make it explorable. Allow entities and actions / functions to be discovered, or even make PoshGraph itself searchable. Then there is no need to leave PoshGraph to identify "docs" -- the tool itself surface the documentation.
+In general, AutoGraphPS also aims to take away the need to look up documentaiton, using much the same approach as Graph Explorer: use the Graph's EDM metadata to make it explorable. Allow entities and actions / functions to be discovered, or even make AutoGraphPS itself searchable. Then there is no need to leave AutoGraphPS to identify "docs" -- the tool itself surface the documentation.
 
 ### The PowerShell and REST ecosystems
-A strength of PowerShell's object pipeline is that it facilitates modifications of objects emitted to the pipeline by any cmdlet. The modifications themselves are accomplished by another cmdlet operating on the pipeline. Thus the objects emitted by PoshGraph may be consumed not just be humans or as input to other commands, but by PowerShell's formatting cmdlets like `format-list` or `format-table`, or data processing cmdlets such as `select-object`, `sort-object`, `where-object`, and `compare-object`. These commands extend the usefulness of cmdlets provided by PoshGraph to richer scenarios in advanced analytics and applications.
+A strength of PowerShell's object pipeline is that it facilitates modifications of objects emitted to the pipeline by any cmdlet. The modifications themselves are accomplished by another cmdlet operating on the pipeline. Thus the objects emitted by AutoGraphPS may be consumed not just be humans or as input to other commands, but by PowerShell's formatting cmdlets like `format-list` or `format-table`, or data processing cmdlets such as `select-object`, `sort-object`, `where-object`, and `compare-object`. These commands extend the usefulness of cmdlets provided by AutoGraphPS to richer scenarios in advanced analytics and applications.
 
-Other PowerShell cmdlets such as the `convertto-*` and `convertfrom-*` cmdlets enable interperation with cmdlets or applications that consume alternative data formats such as `csv`. PowerShell's built-in usage of the C# XML serializer type `XmlSerializer` enables XML interoperability. The conversion capabilities, along with PoshGraph's capability to emit raw JSON, allow users to interoperate with non-PowerShell tools, including REST utilities popular in web app and API development.
+Other PowerShell cmdlets such as the `convertto-*` and `convertfrom-*` cmdlets enable interperation with cmdlets or applications that consume alternative data formats such as `csv`. PowerShell's built-in usage of the C# XML serializer type `XmlSerializer` enables XML interoperability. The conversion capabilities, along with AutoGraphPS's capability to emit raw JSON, allow users to interoperate with non-PowerShell tools, including REST utilities popular in web app and API development.
 
-Beyond the standard cmdlets included in PowerShell itself, repositories such as PowerShell Gallery and Nuget.Org provide a wide range of open source PowerShell modules that extend PowerShell. These libraries enable more than just scripting -- in concert with PoshGraph full-scale applicaitons may be built with PoshGraph. Such modules can also extend the user experience provided by PoshGraph through richer formatting or query facilities.
+Beyond the standard cmdlets included in PowerShell itself, repositories such as PowerShell Gallery and Nuget.Org provide a wide range of open source PowerShell modules that extend PowerShell. These libraries enable more than just scripting -- in concert with AutoGraphPS full-scale applicaitons may be built with AutoGraphPS. Such modules can also extend the user experience provided by AutoGraphPS through richer formatting or query facilities.
 
 ### The missing PowerShell SDK for Graph
-Given that PowerShell as a language has the same expressibilty and concepts as Javascript, Ruby, et. al., each of which have respective Graph SDKs, it makes sense to ask where the equivalent Graph SDK cand be found for Graph. PoshGraph is that SDK, and because it uses a simple layering on top of the Graph API, it is a robust experience that does not require PowerShell users to constantly update to the latest version of PoshGraph to use new Graph features.
+Given that PowerShell as a language has the same expressibilty and concepts as Javascript, Ruby, et. al., each of which have respective Graph SDKs, it makes sense to ask where the equivalent Graph SDK cand be found for Graph. AutoGraphPS is that SDK, and because it uses a simple layering on top of the Graph API, it is a robust experience that does not require PowerShell users to constantly update to the latest version of AutoGraphPS to use new Graph features.
 
 ### Powered by PowerShell
 
-It's not just the user interface of PoshGraph that is based on PowerShell -- PoshGraph itself is written entirely in PowerShell, modulo external auth library dependencies.
+It's not just the user interface of AutoGraphPS that is based on PowerShell -- AutoGraphPS itself is written entirely in PowerShell, modulo external auth library dependencies.
 
-This choice is rather unusual -- C# is typically the language used for non-trivial cmdlet modules like PoshGraph.
+This choice is rather unusual -- C# is typically the language used for non-trivial cmdlet modules like AutoGraphPS.
 
-The reason behind the decision is simple: Given that the choice was made to base PoshGraph's UX in PowerShell, it's easier for those PowerShell users of PoshGraph to contribute to the project through PowerShell rather than C#:
-  * More of PoshGraph's users know PowerShell compared to those who know C#. Those new to Windows-oriented technologies or trained with a systems administration focus may never have encountered C#. The larger pool of PowerShell users empowers a larger pool of potential contributors.
-  * PowerShell is faster for rapid development scenarios: Everything you need to develop new PowerShell scripts is already installed on any modern Windows system. If PoshGraph runs on the system where you install it, you know you can write and test code for it. Exercising a change is as simple as editing text files and then running the relevant PowerShell cmdlets just as in everyday use of PoshGraph. To develop using C#, a fairly large IDE must be installed (after a reboot or two), that IDE and compiler tools *must* be a version compatible with the project's chosen version, and after editing source code a build step is required to exercise the change
+The reason behind the decision is simple: Given that the choice was made to base AutoGraphPS's UX in PowerShell, it's easier for those PowerShell users of AutoGraphPS to contribute to the project through PowerShell rather than C#:
+  * More of AutoGraphPS's users know PowerShell compared to those who know C#. Those new to Windows-oriented technologies or trained with a systems administration focus may never have encountered C#. The larger pool of PowerShell users empowers a larger pool of potential contributors.
+  * PowerShell is faster for rapid development scenarios: Everything you need to develop new PowerShell scripts is already installed on any modern Windows system. If AutoGraphPS runs on the system where you install it, you know you can write and test code for it. Exercising a change is as simple as editing text files and then running the relevant PowerShell cmdlets just as in everyday use of AutoGraphPS. To develop using C#, a fairly large IDE must be installed (after a reboot or two), that IDE and compiler tools *must* be a version compatible with the project's chosen version, and after editing source code a build step is required to exercise the change
 
-The use of PowerShell rather than C# results in a substantially lower overhead of development and its more widespread penetration as a language for PoshGraph's target pool of users means more possible contributors. Both of these factors should increase the probabilty that users can and will contribute to PoshGraph.
+The use of PowerShell rather than C# results in a substantially lower overhead of development and its more widespread penetration as a language for AutoGraphPS's target pool of users means more possible contributors. Both of these factors should increase the probabilty that users can and will contribute to AutoGraphPS.
 
-### What's not in PoshGraph?
+### What's not in AutoGraphPS?
 
-Given the positioning of PoshGraph as interactive tool, teaching instrument, and SDK, is there anything it can't do?
+Given the positioning of AutoGraphPS as interactive tool, teaching instrument, and SDK, is there anything it can't do?
 
-Absolutely. The best way to understand its limitations is simply to view PoshGraph as a thin but capable PowerShell layer on top of the Graph API, one that supports human interaction. With this framing, PoshGraph is clearly not an application in and of itself any more than the Graph API. Thus, fully-realized applications or functionality that operates on a subset of the Graph are out of scope for Graph. Such examples include:
+Absolutely. The best way to understand its limitations is simply to view AutoGraphPS as a thin but capable PowerShell layer on top of the Graph API, one that supports human interaction. With this framing, AutoGraphPS is clearly not an application in and of itself any more than the Graph API. Thus, fully-realized applications or functionality that operates on a subset of the Graph are out of scope for Graph. Such examples include:
 * An Graph-based e-mail client
 * A utility for managing OneDrive files
 * A custom tree view of Azure Active Directory
 * Dedicated cmdlets for SharePoint
 
-In general, any capability that is relevant to the entire Graph is worthy of consideration for PoshGraph, particularly those capabilities that align with the wish list and conform to the PoshGraph design choices.
+In general, any capability that is relevant to the entire Graph is worthy of consideration for AutoGraphPS, particularly those capabilities that align with the wish list and conform to the AutoGraphPS design choices.
 
 ## Where next?
 
-The PoshGraph project's initial focus was to prove the concept of a PowerShell-based Graph explorer. These first implementations delivered a simplifed authentication and authorization experience, navigation UX through the Graph's Entity Data Model metadata, and `GET`-based read-only Graph API calls through easy to use PowerShell objects instead of JSON.
+The AutoGraphPS project's initial focus was to prove the concept of a PowerShell-based Graph explorer. These first implementations delivered a simplifed authentication and authorization experience, navigation UX through the Graph's Entity Data Model metadata, and `GET`-based read-only Graph API calls through easy to use PowerShell objects instead of JSON.
 
 There are, then, some obvious next steps for the project in terms of both features and making the project useful to the community of Graph users:
 
@@ -148,7 +148,7 @@ There are, then, some obvious next steps for the project in terms of both featur
 * Graph API method invocation with parameter passing
 * Keyword search on entities and locations in the Graph
 * Extension of the file system metaphore for move, copy, and similar semantics
-* New projects to provide domain-specific cmdlets built on PoshGraph (e.g. file management, email, etc.)
-* PoshGraph equivalents for other languages -- Python anyone?
+* New projects to provide domain-specific cmdlets built on AutoGraphPS (e.g. file management, email, etc.)
+* AutoGraphPS equivalents for other languages -- Python anyone?
 
-These are suggestions. Ultimately for the project to move beyond a proof of concept, it is the community that must provide the guidance and source contributions that make PoshGraph a truly useful gateway to the Graph.
+These are suggestions. Ultimately for the project to move beyond a proof of concept, it is the community that must provide the guidance and source contributions that make AutoGraphPS a truly useful gateway to the Graph.

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -1,16 +1,16 @@
-PoshGraph Walkthrough
+AutoGraphPS Walkthrough
 =====================
 
-This walkthrough will expose you to the key capabilities of PoshGraph and the Microsoft Graph. It is certainly not exhaustive, but should be enough for you understand how to use PoshGraph in your work, where it falls short, and how you might remedy any omissions with your own contributions to the project.
+This walkthrough will expose you to the key capabilities of AutoGraphPS and the Microsoft Graph. It is certainly not exhaustive, but should be enough for you understand how to use AutoGraphPS in your work, where it falls short, and how you might remedy any omissions with your own contributions to the project.
 
 The walkthrough assumes you are familiar with PowerShell and basic usage of the object pipeline, and that you are familiar with REST concepts.
 
-## How to explore with PoshGraph
-After you've installed the module, invoke PoshGraph cmdlets from any PowerShell session.
+## How to explore with AutoGraphPS
+After you've installed the module, invoke AutoGraphPS cmdlets from any PowerShell session.
 
 ### Get started -- simple commands
 
-**PoshGraph** cmdlets allow you to explore the graph. Before using the cmdlets, you must establish a connection to the graph. The easiest approach is to use the `Connect-Graph` cmdlet, after which you can execute other cmdlets such as `Get-GraphItem` which operate on the graph:
+**AutoGraphPS** cmdlets allow you to explore the graph. Before using the cmdlets, you must establish a connection to the graph. The easiest approach is to use the `Connect-Graph` cmdlet, after which you can execute other cmdlets such as `Get-GraphItem` which operate on the graph:
 
 ```powershell
 Get-GraphItem me
@@ -55,7 +55,7 @@ Here's how you can request the `Files.Read,` `Mail.Read`, and `Contacts.Read` sc
 Connect-Graph User.Read, Files.Read, Mail.Read, Contacts.Read
 ```
 
-This will prompt you to authenticate again and consent to allow the application to acquire these permissions. Note that it is generally not obvious what scopes are required to access different functionality in the Graph; future updates to PoshGraph will attempt to address this. For now, consult the [Graph permissions documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference) whenever you're accessing a new part of the Graph.
+This will prompt you to authenticate again and consent to allow the application to acquire these permissions. Note that it is generally not obvious what scopes are required to access different functionality in the Graph; future updates to AutoGraphPS will attempt to address this. For now, consult the [Graph permissions documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference) whenever you're accessing a new part of the Graph.
 
 In addition to the `get-graphitem` cmdlet which returns data as a series of flat lists, you can use `get-graphchilditem` or its alias `gls` to retrieve your personal contacts:
 
@@ -154,9 +154,9 @@ You may have noticed that after the first time you invoked `Get-GraphChildItem`,
 PS>
 ```
 
-By default, PoshGraph automatically adds this to your path on your first use of the exploration-oriented cmdlets `Get-GraphChildItem` and `Set-GraphLocation` (alias `gcd`). The text in square brackets denotes the user identity with which you've logged in. The next part before the `:` tells you what Graph API version you're using, in this case the default of `v1.0`. The part following this is your *location* within that API version. Any Uris specified to `Get-GraphChildItem`, `Get-GraphItem`, or `Set-GraphLocation` are interpreted as relative to the current location, in very much the same way that file-system oriented shells like `bash` and PowerShell interpret paths specified to commands as relative to the current working directory. In this case, your current location in the Graph is `/`, the root of the graph.
+By default, AutoGraphPS automatically adds this to your path on your first use of the exploration-oriented cmdlets `Get-GraphChildItem` and `Set-GraphLocation` (alias `gcd`). The text in square brackets denotes the user identity with which you've logged in. The next part before the `:` tells you what Graph API version you're using, in this case the default of `v1.0`. The part following this is your *location* within that API version. Any Uris specified to `Get-GraphChildItem`, `Get-GraphItem`, or `Set-GraphLocation` are interpreted as relative to the current location, in very much the same way that file-system oriented shells like `bash` and PowerShell interpret paths specified to commands as relative to the current working directory. In this case, your current location in the Graph is `/`, the root of the graph.
 
-With PoshGraph, you can traverse the Graph using `gls` and `gcd` just the way you'd traverse your file system using `ls` to "see" what's in and under the current location and "move" to a new location. Here's an example of exploring the `/drive` entity, i.e. the entity that represents your `OneDrive` files:
+With AutoGraphPS, you can traverse the Graph using `gls` and `gcd` just the way you'd traverse your file system using `ls` to "see" what's in and under the current location and "move" to a new location. Here's an example of exploring the `/drive` entity, i.e. the entity that represents your `OneDrive` files:
 
 ```
 gcd me/drive/root/children
@@ -224,11 +224,11 @@ v1.0:/me/drive/root/children/candidates/children
 
 The Microsoft Graph supports a rich set of query capabilities through its [OData](https://www.odata.org) support. You can learn the the specifics of MS Graph and OData query specification as part of MS Graph REST Uri's via [Graph's query documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/query_parameters), the [OData query tutorial](http://www.odata.org/getting-started/basic-tutorial/#queryData), or simply by using the [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
 
-To use PoshGraph's query capabilities are exposed in the `Get-GraphItem` and `Get-GetGraphChildItem` cmdletes (`ggi` and `gls` aliases respectively). To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
+To use AutoGraphPS's query capabilities are exposed in the `Get-GraphItem` and `Get-GetGraphChildItem` cmdletes (`ggi` and `gls` aliases respectively). To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
 
 ### Filtering data with `-ODataFilter`
 
-The one area of PoshGraph usage in which it is helpful to understand OData is the filtering language. The `-ODataFilter` option on `Get-GraphItem` and `Get-GraphChildItem` allows you to specify an OData query to limit the result set from Graph to items that satisfy certain conditions much like a SQL `where` clause. The query is performed by the Graph service, so your network and PoshGraph don't have to waste time processing results that don't match the criteria you specified:
+The one area of AutoGraphPS usage in which it is helpful to understand OData is the filtering language. The `-ODataFilter` option on `Get-GraphItem` and `Get-GraphChildItem` allows you to specify an OData query to limit the result set from Graph to items that satisfy certain conditions much like a SQL `where` clause. The query is performed by the Graph service, so your network and AutoGraphPS don't have to waste time processing results that don't match the criteria you specified:
 
 ```powershell
 gls me/people -ODataFilter "department eq 'Ministry of Funk'"
@@ -247,7 +247,7 @@ Complex expressions combining multiple operators using logical operators like `a
 
 ### Limiting enumerations with `-First` and `-Skip`
 
-Another way to avoid excessive traffic between PoshGraph and Graph is to use the `-First` and `-Skip` options, which are [PowerShell standard parameters for paging](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-6#supportspaging). These options are implemented as analogs to the `$top` and `$skip` options in OData syntax. For example:
+Another way to avoid excessive traffic between AutoGraphPS and Graph is to use the `-First` and `-Skip` options, which are [PowerShell standard parameters for paging](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-6#supportspaging). These options are implemented as analogs to the `$top` and `$skip` options in OData syntax. For example:
 
 ```powershell
 gls me/contacts -first 3
@@ -329,7 +329,7 @@ The `$false` assignment in the hash table means that the field will use *ascendi
 
 ### Advanced queries with `-Query`
 
-The `-Query` option lets you directly specify the Uri query parameters for the Graph call made by PoshGraph. It must conform to [OData specifications](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752360). The option is provided to allow you to overcome limitations in PoshGraph's simpler query options. For example the two commands below are equivalent:
+The `-Query` option lets you directly specify the Uri query parameters for the Graph call made by AutoGraphPS. It must conform to [OData specifications](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752360). The option is provided to allow you to overcome limitations in AutoGraphPS's simpler query options. For example the two commands below are equivalent:
 
 ```
 gls /users -ODataFilter "startsWith(mail, 'p')" -top 20
@@ -338,7 +338,7 @@ gls /users -Query       "`$filter=startsWith(mail, 'p')&`top=20"
 
 Note that `-Query` requires you to understand how to combine multiple query options via '&' and also how to make correct use of PowerShell escape characters so that OData tokens like `$top` which are preceded by the `$` character which is reserved as a variable prefix in PowerShell are taken literally instead of as the value of a PowerShell variable.
 
-While `-Query` may be more complicated to use, when PoshGraph's other query options do not support a particular Graph query feature, you still have a way to use Graph's full capabilities.
+While `-Query` may be more complicated to use, when AutoGraphPS's other query options do not support a particular Graph query feature, you still have a way to use Graph's full capabilities.
 
 For more details on how to construct this parameter, see the [MS Graph REST API documentation for queries](https://developer.microsoft.com/en-us/graph/docs/concepts/query_parameters).
 
@@ -354,7 +354,7 @@ This results in an error:
 
 ```
 Invoke-WebRequest : The remote server returned an error: (400) Bad Request.
-At C:\users\adamed\src\poshgraph\src\rest\restrequest.ps1:73 char:17
+At C:\users\myuser\Documents\WindowsPowerShell\modules\autographps-sdk\0.4.0\src\rest\restrequest.ps1:73 char:17
 + ...             Invoke-WebRequest -Uri $this.uri -headers $this.headers - ...
 +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
@@ -403,14 +403,14 @@ t +> user PFunk 4Life 30285b8b-70ba-42e0-9bd9-fbcee5d1ce64
 You can inspect the various properties and object returned by `Get-GraphError` to find additional details that help you debug a failure.
 
 ### Diagnostic output via `-verbose`
-All PoshGraph cmdlets support the PowerShell standard option `-verbose` and the associated `$VerbosePreference` preference variable. When using cmdlets such as `Get-GraphItem` and `Get-GraphChildItem`, specifying `-verbose` will output not only the `http` verb and `uri` used to access the Graph, but also the request headers and for responses the response body and headers.
+All AutoGraphPS cmdlets support the PowerShell standard option `-verbose` and the associated `$VerbosePreference` preference variable. When using cmdlets such as `Get-GraphItem` and `Get-GraphChildItem`, specifying `-verbose` will output not only the `http` verb and `uri` used to access the Graph, but also the request headers and for responses the response body and headers.
 
 By default, the response body is truncated after a certain length, though the behavior can be overridden by setting `GraphVerboseOutputPreference` to `High`.
 
 ### Authorization errors
-Microsoft Graph requires callers to obtain specific authorization for applications like PoshGraph to access particular capabilities of the Graph. Because the mapping of required scopes to functionality is currently only available through human-readable [documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference ), it's easy for developers and other human users of applications including PoshGraph to encounter errors due to insufficient scopes.
+Microsoft Graph requires callers to obtain specific authorization for applications like AutoGraphPS to access particular capabilities of the Graph. Because the mapping of required scopes to functionality is currently only available through human-readable [documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference ), it's easy for developers and other human users of applications including AutoGraphPS to encounter errors due to insufficient scopes.
 
-Often, users and developers remedy the error by reading the documentation, and updating the application to request the missing scopes. PoshGraph tries to hasten such fixes by surfacing authorization failures with a warning encouring the user to request additional scopes as in the example below where the caller tries to access `me/people` to get information about the people with whom she has been interacting:
+Often, users and developers remedy the error by reading the documentation, and updating the application to request the missing scopes. AutoGraphPS tries to hasten such fixes by surfacing authorization failures with a warning encouring the user to request additional scopes as in the example below where the caller tries to access `me/people` to get information about the people with whom she has been interacting:
 
 ```
 PS> gls me/people
@@ -430,11 +430,11 @@ WARNING: {
 }
 ```
 
-The warning message in the PoshGraph output includes a link to the permissions documentation and suggestion to use `Connect-Graph` to grant PoshGraph additional permissions. Consultation of the documentation may lead the user to conclude that PoshGraph is missing the 'People.Read' scope, and a retry of the original attempt after using `Connect-Graph` to request `People.Read` will succeed:
+The warning message in the AutoGraphPS output includes a link to the permissions documentation and suggestion to use `Connect-Graph` to grant AutoGraphPS additional permissions. Consultation of the documentation may lead the user to conclude that AutoGraphPS is missing the 'People.Read' scope, and a retry of the original attempt after using `Connect-Graph` to request `People.Read` will succeed:
 
 ```powershell
 # This will prompt the user to re-authenticate and grant People.Read
-# to PoshGraph
+# to AutoGraphPS
 Connect-Graph People.Read
 
 gls me/people
@@ -518,7 +518,7 @@ In the above example, `Get-GraphUri` parsed the Uri in order to generate the ret
 ```
 Get-GraphUri /me/idontexist
 Uri '/me/idontexist' not found: no matching child segment 'idontexist' under segment 'me'
-At C:\users\adamed\src\poshgraph\src\metadata\segmentparser.ps1:140 char:21
+At C:\users\myuser\Documents\WindowsPowerShell\modules\autographps\0.14.0\src\metadata\segmentparser.ps1:140 char:21
 + ...             throw "Uri '$($Uri.tostring())' not found: no matching ch ...
 +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : OperationStopped: (Uri '/me/idonte...er segment 'me':String) [], RuntimeExcept
@@ -632,7 +632,7 @@ The `{driveItem}` segment tells you format of a hypothetical segment that could 
 
 ### USing Get-GraphToken with other Graph tools
 
-When using tools like Postman or Fiddler to troubleshoot or test the Graph, you'll need to acquire a token. Token acquisition continues to be one of the biggest barriers to using Graph, so use PoshGraph's `Get-GraphToken` cmdlet to automate it:
+When using tools like Postman or Fiddler to troubleshoot or test the Graph, you'll need to acquire a token. Token acquisition continues to be one of the biggest barriers to using Graph, so use AutoGraphPS's `Get-GraphToken` cmdlet to automate it:
 
 ```powershell
 Get-GraphToken


### PR DESCRIPTION
### Description

Fixes references in docs to the name `poshgraph`, particularly URI's referencing this repository, that should now be changed to `autographps` due to the recent rename of the module and this repository.