### PR TITLE
Improved support for managing custom graphs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Switch build system to dotnet
 * Investigate gls ignoring 400's
 * Investigate pipeline behavior to Get-GraphRelatedItem
 * Update build script to skip powershell profile by default for import-devmodule

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,7 +132,6 @@
 * Show-GraphRequest
 * Fix bug with graph update not clearing uri cache due to async
 * Enable schemaless execution
-* Auto-refresh token when expired
 * Use BEGIN, PROCESS, END in get-graphuri
 * Add basic help
 * Add uri completion
@@ -158,9 +157,6 @@
 * common scopes -- use dynamicparam
 * scope browser
 * Add unit tests for parameters
-* Enable token refresh
-* Enable app-only auth
-* Add reply url to new-graphconnection -- only works with confidential client
 * Graph tracing
 * Graph trace replay
 * entity templates
@@ -250,6 +246,8 @@
 * Make connect-graph connect in the custom case
 * Make content-columns auto-avoid collisions
 * Rudimentary token auto-refresh
+* Enable app-only auth
+* Add reply url to new-graphconnection
 * Make graph drive collision nicer
 * Link to scopes docs when unauthorized
 * Fix bug where context is assumed to be current rather than from uri

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -258,13 +258,12 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS 0.43.0 Release Notes
 
-Update to new AutoGraphPS-SDK, ScriptClass dependences, bug fixes.
+Update to new AutoGraphPS-SDK, MSAL, and custom API metadata improvements.
 
 ### New dependencies
 
 * AutoGraphPS-SDK 0.31.0
-* // Microsft.Identity.Client 4.50.0 -- i.e. MSAL
-* // Microsoft.IdentityModel.Abstractions 6.22.0 -- new dependency in this release brought in by MSAL update
+* Microsft.Identity.Client 4.64.0 -- i.e. MSAL
 
 ### Breaking changes
 
@@ -272,7 +271,12 @@ None.
 
 ### New features
 
-None.
+* The `New-Graph` command supports two new parameters to enable custom API metadata:
+  *  The `SchemaUri` parameter: this can point to a remote https scheme URI or even a local file system path
+     that conatins the OData metadata document for the API specification that defines the graph structure, i.e.
+     the same kind of content that is available at real API versions such as https://graph.microsoft.com/v1.0/$metadata.
+  *  The `SchemaMetadata` parameter: this is the actual content of the API schema document; it may be useful to specify this
+     in cases where the metadata has been downloaded or constructed out of band of any commands
 
 ### Fixed defects
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -263,7 +263,7 @@ Update to new AutoGraphPS-SDK, MSAL, and custom API metadata improvements.
 ### New dependencies
 
 * AutoGraphPS-SDK 0.31.0
-* Microsft.Identity.Client 4.64.0 -- i.e. MSAL
+* Microsoft.Identity.Client 4.64.0 -- i.e. MSAL
 
 ### Breaking changes
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -27,7 +27,7 @@ Author = 'Adam Edwards'
 CompanyName = 'Modulus Group'
 
 # Copyright statement for this module
-Copyright = '(c) 2023 Adam Edwards.'
+Copyright = '(c) 2024 Adam Edwards.'
 
 # Description of the functionality provided by this module
 Description = 'The friendly, scriptable Graph Explorer CLI for automating the Microsoft Graph'
@@ -258,7 +258,7 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS 0.43.0 Release Notes
 
-Update to new AutoGraphPS-SDK, MSAL, and custom API metadata improvements.
+Update to new AutoGraphPS-SDK, MSAL, and custom API metadata improvements. CI pipeline updates.
 
 ### New dependencies
 
@@ -273,7 +273,7 @@ None.
 
 * The `New-Graph` command supports two new parameters to enable custom API metadata:
   *  The `SchemaUri` parameter: this can point to a remote https scheme URI or even a local file system path
-     that conatins the OData metadata document for the API specification that defines the graph structure, i.e.
+     that contains the OData metadata document for the API specification that defines the graph structure, i.e.
      the same kind of content that is available at real API versions such as https://graph.microsoft.com/v1.0/$metadata.
   *  The `SchemaMetadata` parameter: this is the actual content of the API schema document; it may be useful to specify this
      in cases where the metadata has been downloaded or constructed out of band of any commands

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.42.0'
+ModuleVersion = '0.43.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -67,7 +67,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml', './src/comm
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.30.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.31.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.3';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
     @{ModuleName='ThreadJob';ModuleVersion='2.0.3';Guid='0e7b895d-2fec-43f7-8cae-11e8d16f6e40'}
 )
@@ -256,31 +256,28 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.42.0 Release Notes
+## AutoGraphPS 0.43.0 Release Notes
 
 Update to new AutoGraphPS-SDK, ScriptClass dependences, bug fixes.
 
 ### New dependencies
 
-* ScriptClass 0.20.3
-* AutoGraphPS-SDK 0.30.0
-* Microsft.Identity.Client 4.50.0 -- i.e. MSAL
-* Microsoft.IdentityModel.Abstractions 6.22.0 -- new dependency in this release brought in by MSAL update
+* AutoGraphPS-SDK 0.31.0
+* // Microsft.Identity.Client 4.50.0 -- i.e. MSAL
+* // Microsoft.IdentityModel.Abstractions 6.22.0 -- new dependency in this release brought in by MSAL update
 
 ### Breaking changes
 
-* See breaking changes for AutoGraphPS-SDK 0.30.0
+None.
 
 ### New features
 
-* `Set-GraphItem`, `New-GraphItem`, `Get-GraphItem`, and `Remove-GraphItem` now support a `Headers` parameter that allows headers to be specified
-* `Get-GraphRelatedItem` supports the `Select` parameter to project specific properties of the objects returned by the command
+None.
 
 ### Fixed defects
 
-* `Measure-Graph` and any commands accessing API metadata information about enumeration types may fail when acting on the most recent Graph API `beta` version when an enumeration has no members
-* `Find-GraphType` failing for `beta` API version where a type had a property called `keys` because of subtle non-deterministic, PowerShell syntactic sugar behavior with keyed collection string keys being automagically elevated to properties of the collection itself and this obscures real properties with name collisions (in this case the `keys` property of the collection used by the module to process property information): https://github.com/PowerShell/PowerShell/issues/7758
-* The `First` parameter of `Get-GraphRelatedItem` did not function and could cause errors -- this has been fixed.
+* `Remove-Graph` was completely broken, it would always throw an exception and not remove the graph. This is fixed.
+
 '@
     } # End of PSData hashtable
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     inputs:
       azureSubscription: 'Azure Free Trial(439deb75-e36b-4569-b075-f2c2448e8a3e)'
       KeyVaultName: 'CI-AutoGraphPS-SDK'
-      SecretsFilter: 'AutoGraph-CI-Pipeline-Cert-Exp-2024-01-20'
+      SecretsFilter: 'CI-AutoGraph-App-Certificate'
       RunAsPreJob: false
   - task: powershell@2
     displayName: 'Show current PowerShell version information'
@@ -57,7 +57,7 @@ jobs:
     displayName: 'Install Pester test framework required version'
     inputs:
       targetType: inline
-      script: 'Install-Module Pester -RequiredVersion 4.8.1 -scope currentuser -force'
+      script: 'Install-Module Pester -RequiredVersion 4.8.1 -scope currentuser -force -skippublishercheck'
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Get updated Pester test framework module version'
@@ -120,7 +120,7 @@ jobs:
     displayName: 'Run integration tests'
     inputs:
       targetType: inline
-      script: './test/CI/RunIntegrationTests.ps1 -TestRoot test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(AutoGraph-CI-Pipeline-Cert-Exp-2024-01-20) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_INTEGRATION_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
+      script: './test/CI/RunIntegrationTests.ps1 -TestRoot test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(CI-AutoGraph-App-Certificate) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_INTEGRATION_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
       pwsh: $(USE_POWERSHELL_CORE)
   - task: PublishTestResults@2
     inputs:

--- a/build/install.ps1
+++ b/build/install.ps1
@@ -93,6 +93,12 @@ function InstallDependencies($clean) {
             }
 
             foreach ( $sourceLibrary in $platformSourceLibraries ) {
+                # So now there are some new '/ref/' directories in .net6 and later releases that include various superfluous
+                # binaries, so we explicitly filter these out. :(
+                if ( ( split-path -leaf ( split-path -parent ( split-path -Parent $sourceLibrary.FullName ) ) ) -eq 'ref' ) {
+                    continue
+                }
+
                 move-item $sourceLibrary.FullName $platformDirectory
             }
         }

--- a/docs/MOTIVATION.md
+++ b/docs/MOTIVATION.md
@@ -104,7 +104,7 @@ A strength of PowerShell's object pipeline is that it facilitates modifications 
 
 Other PowerShell cmdlets such as the `convertto-*` and `convertfrom-*` cmdlets enable interperation with cmdlets or applications that consume alternative data formats such as `csv`. PowerShell's built-in usage of the C# XML serializer type `XmlSerializer` enables XML interoperability. The conversion capabilities, along with AutoGraphPS's capability to emit raw JSON, allow users to interoperate with non-PowerShell tools, including REST utilities popular in web app and API development.
 
-Beyond the standard cmdlets included in PowerShell itself, repositories such as PowerShell Gallery and Nuget.Org provide a wide range of open source PowerShell modules that extend PowerShell. These libraries enable more than just scripting -- in concert with AutoGraphPS full-scale applicaitons may be built with AutoGraphPS. Such modules can also extend the user experience provided by AutoGraphPS through richer formatting or query facilities.
+Beyond the standard cmdlets included in PowerShell itself, repositories such as PowerShell Gallery and Nuget.Org provide a wide range of open source PowerShell modules that extend PowerShell. These libraries enable more than just scripting -- in concert with AutoGraphPS full-scale applications may be built with AutoGraphPS. Such modules can also extend the user experience provided by AutoGraphPS through richer formatting or query facilities.
 
 ### The missing PowerShell Programming Gateway for the Graph protocol
 Given that PowerShell as a language has the same expressibilty and concepts as Javascript, Ruby, et. al., each of which have respective Graph SDKs, it makes sense to ask where a similar developer interface may be found for Graph. AutoGraphPS is that programming surface, and because it uses a simple layering on top of the Graph API, it is a robust experience that does not require PowerShell users to constantly update to the latest version of AutoGraphPS to use new Graph features.
@@ -143,7 +143,7 @@ There are, then, some obvious next steps for the project in terms of both featur
 * More tests to enable contributions from more than just the original maintainer
 * Cmdlet help
 * Performance enhancements
-* Extension of the file system metaphore for move, copy, and similar semantics
+* Extension of the file system metaphor for move, copy, and similar semantics
 * New projects to provide domain-specific cmdlets built on AutoGraphPS (e.g. file management, email, etc.)
 * AutoGraphPS equivalents for other languages -- Python anyone?
 

--- a/src/cmdlets/Get-Graph.ps1
+++ b/src/cmdlets/Get-Graph.ps1
@@ -82,10 +82,16 @@ function Get-Graph {
 
     $graphContexts = $::.LogicalGraphManager |=> Get |=> GetContext
 
-    $graphContexts |
+    $result = $graphContexts |
       where { ! $targetGraph -or $_.name -eq $targetGraph } | foreach {
           $::.ContextHelper |=> ToPublicContext $_
       } | sort-object Name
+
+    if ( $Name -and ! $result ) {
+        throw "The specified Graph '$Name' does not exist."
+    }
+
+    $result
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-Graph Name (new-so GraphParameterCompleter)

--- a/src/cmdlets/Get-Graph.tests.ps1
+++ b/src/cmdlets/Get-Graph.tests.ps1
@@ -48,5 +48,12 @@ Describe 'The Get-Graph cmdlet' {
 
             { Get-Graph $newGraph.Name } | Should Throw
         }
+
+        It "Should throw an exception if a new graph is created with the same name as an existing graph" {
+
+            $originalGraph = new-graph originalGraph
+
+            { $duplicatedNameGraph = new-graph $originalGraph.Name } | Should Throw
+        }
     }
 }

--- a/src/cmdlets/Get-Graph.tests.ps1
+++ b/src/cmdlets/Get-Graph.tests.ps1
@@ -1,0 +1,52 @@
+# Copyright (c) Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Describe 'The Get-Graph cmdlet' {
+    BeforeEach {
+        Get-Graph | Remove-Graph -warningaction silentlycontinue 3>&1 | out-null
+    }
+
+    AfterEach {
+        Get-Graph | Remove-Graph -warningaction silentlycontinue 3>&1 | out-null
+    }
+
+    Context 'When invoking the Get-Graph command' {
+        It "Should successfully return the default if there is no other graph mounted" {
+            Get-Graph | Select -expandproperty name | Should Be 'v1.0'
+        }
+
+        It "Should throw an exception if a the graph with the specified name does not exist" {
+            { Get-Graph idontexist } | Should Throw
+        }
+
+        It "Should return a new graph if it is added" {
+            $newGraph = new-graph NewGraph1
+
+            $newGraph.Name | Should be NewGraph1
+
+            Get-Graph $newGraph.Name | select -expandproperty Name | Should be $newGraph.Name
+        }
+
+        It "Should throw an exception if a graph is removed by name and immediately specified by name" {
+            $newGraph = new-graph NewGraphRemoved
+
+            { Get-Graph $newGraph.Name } | Should Not Throw
+
+            Remove-Graph $newGraph.Name
+
+            { Get-Graph $newGraph.Name } | Should Throw
+        }
+    }
+}

--- a/src/cmdlets/Get-Graph.tests.ps1
+++ b/src/cmdlets/Get-Graph.tests.ps1
@@ -48,12 +48,5 @@ Describe 'The Get-Graph cmdlet' {
 
             { Get-Graph $newGraph.Name } | Should Throw
         }
-
-        It "Should throw an exception if a new graph is created with the same name as an existing graph" {
-
-            $originalGraph = new-graph originalGraph
-
-            { $duplicatedNameGraph = new-graph $originalGraph.Name } | Should Throw
-        }
     }
 }

--- a/src/cmdlets/Measure-Graph.ps1
+++ b/src/cmdlets/Measure-Graph.ps1
@@ -105,6 +105,10 @@ function Measure-Graph {
 
     $targetContext = $::.ContextHelper |=> GetContextByNameOrDefault $GraphName
 
+    if ( ! $targetContext ) {
+        throw "The specified graph named '$GraphName' could not be found."
+    }
+
     $typeSearcher = $::.TypeManager |=> Get $targetContext |=> GetTypeSearcher
 
     $indexClasses = 'Name', 'Property', 'NavigationProperty'
@@ -124,4 +128,4 @@ function Measure-Graph {
     }
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Measure-Graph Name (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Measure-Graph GraphName (new-so GraphParameterCompleter)

--- a/src/cmdlets/New-Graph.ps1
+++ b/src/cmdlets/New-Graph.ps1
@@ -91,7 +91,13 @@ function New-Graph {
     $graphConnection = if ( $Connection ) {
         $Connection
     } else {
-        ($::.GraphContext |=> GetCurrent).connection
+        $currentContext = ($::.GraphContext |=> GetCurrent)
+
+        if ( $currentContext ) {
+            $currentContext.connection
+        } else {
+            New-GraphConnection
+        }
     }
 
     $context = $::.LogicalGraphManager |=> Get |=> NewContext $null $graphConnection $Version $Name

--- a/src/cmdlets/New-Graph.ps1
+++ b/src/cmdlets/New-Graph.ps1
@@ -36,6 +36,12 @@ Specify the Version parameter to set the API version of the graph. If this param
 .PARAMETER Name
 Every graph must have a unique name -- specify the unique name of the graph through the Name parameter. If no name is specified, a unique name is automatically generated based on properties of the graph such as its API version.
 
+.PARAMETER SchemaUri
+Specify this parameter to override the default API metadata document location associated with the API endpoint so that the metadata from that document will be used against the API endpoint instead of the default metadata surfaced at the API endpoint itself.. The URI must either be a valid https or file scheme URI, or it may also be a valid local file system path.
+
+.PARAMETER SchemaData
+Specify the SchemaData parameter to provide the XML string-formatted Common Schema Definition Language (CSDL) schema that must be used to construct API requests sent to the API endpoint and also interpret the responses from that endpoint. This will override the content of any schema document supplied at the endpoint.
+
 .PARAMETER Connection
 Specifies graph connection object to associate with this graph. The connection object contains information about the service endpoints for the Graph API and parameters related to the authentication and authorization for the identity used to access the Graph API. Commands that interact with the Graph API will access the Graph API according to the properties of the graph's associated connection. If the Connection parameter is not specified, the current connection is associated with the Graph.
 
@@ -68,6 +74,23 @@ v1.0_1 v1.0    https://graph.microsoft.com/
 
 If no parameters are specified, then the graph's API version defaults to v1.0, and therefore the unspecified name is set to a variation of that API version. Since there was already a graph named 'v1.0', the unique name 'v1.0_1' is generated from the API version.
 
+.EXAMPLE
+New-Graph -Name OldAPIVersion -SchemaUri ~/schemas/2021-metadata-snapshot.csdl
+
+   Graph Name: OldAPIVersion
+
+Id                     : 44452774-7618-4f2d-b0a1-21250f9df78d
+Endpoint               : https://graph.microsoft.com/
+Version                : v1.0
+CurrentLocation        : /
+AuthEndpoint           : https://login.microsoftonline.com/
+Metadata               : Ready
+CreationTime           : 9/2/2024 4:38:14 PM
+LastUpdateTime         : 9/2/2024 4:38:14 PM
+LastTypeMetadataSource : C:\Users\myuser\schemas\2021-metadata-snapshot.csdl
+
+This command creates a new graph naemd 'OldAPIVersion' based on the API metadata at a local file system location rather than the API metadata at the default location for the endpoint, https://graph.microsoft.com/v1.0/$metadata. This could be useful for comparing changes between Graph API versions over time by downloading snapshots of the metadata document periodically.
+
 .LINK
 New-Graph
 Remove-Graph
@@ -81,11 +104,15 @@ function New-Graph {
 
         $Version = 'v1.0',
 
+        [parameter(parametersetname='SchemaMetadataUri', mandatory=$true)]
         [Uri] $SchemaUri = $null,
 
+        [parameter(parametersetname='CustomMetadata', mandatory=$true)]
         [string] $SchemaData,
 
         [parameter(parametersetname='Connection', mandatory=$true)]
+        [parameter(parametersetname='CustomMetadata')]
+        [parameter(parametersetname='SchemaMetadataUri')]
         $Connection = $null
     )
 

--- a/src/cmdlets/New-Graph.ps1
+++ b/src/cmdlets/New-Graph.ps1
@@ -77,10 +77,13 @@ function New-Graph {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='Simple')]
     param(
         [parameter(position=0)]
+        $Name = $null,
+
         $Version = 'v1.0',
 
-        [parameter(position=1)]
-        $Name = $null,
+        [Uri] $SchemaUri = $null,
+
+        [string] $SchemaData,
 
         [parameter(parametersetname='Connection', mandatory=$true)]
         $Connection = $null
@@ -100,9 +103,9 @@ function New-Graph {
         }
     }
 
-    $context = $::.LogicalGraphManager |=> Get |=> NewContext $null $graphConnection $Version $Name
+    $context = $::.LogicalGraphManager |=> Get |=> NewContext $null $graphConnection $Version $Name $false $SchemaUri
 
-    $::.GraphManager |=> UpdateGraph $context
+    $::.GraphManager |=> UpdateGraph $context $SchemaData $false $false $SchemaUri
 
     $::.ContextHelper |=> ToPublicContext $context
 }

--- a/src/cmdlets/Remove-Graph.ps1
+++ b/src/cmdlets/Remove-Graph.ps1
@@ -51,9 +51,20 @@ function Remove-Graph {
         [string] $Name
     )
 
-    Enable-ScriptClassVerbosePreference
+    begin {
+        Enable-ScriptClassVerbosePreference
+    }
 
-    $::.LogicalGraphManager |=> Get |=> RemoveContext $Name
+    process {
+        # Seems that if you accept pipeline input you can't rely on a mandatory parameter being non-null / non-empty
+        # This likely preserves the output to accept empty results as inputs without throwing an exception.
+        if ( $Name ) {
+            $::.LogicalGraphManager |=> Get |=> RemoveContext $Name
+        }
+    }
+
+    end {
+    }
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Remove-Graph Name (new-so GraphParameterCompleter)

--- a/src/cmdlets/new-graph.tests.ps1
+++ b/src/cmdlets/new-graph.tests.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Describe 'The New-Graph cmdlet' {
+    BeforeEach {
+        Get-Graph | Remove-Graph -warningaction silentlycontinue 3>&1 | out-null
+    }
+
+    AfterEach {
+        Get-Graph | Remove-Graph -warningaction silentlycontinue 3>&1 | out-null
+    }
+
+    Context 'When invoking the New-Graph command' {
+        $referenceMetadataPath = "$psscriptroot/../../test/assets/betametadata-ns-alias-2020-01-23.xml"
+        $differenceMetadataPath = "$psscriptroot/../../test/assets/betametadata-ns-alias-multi-namespace-2020-03-25.xml"
+
+        $expectedTypeDiff = @'
+[
+  {
+    "InputObject": "microsoft.graph.appscope",
+    "SideIndicator": "<="
+  },
+  {
+    "InputObject": "microsoft.graph.grouppolicyobjectfile",
+    "SideIndicator": "<="
+  },
+  {
+    "InputObject": "microsoft.graph.rbacapplicationmultiple",
+    "SideIndicator": "<="
+  },
+  {
+    "InputObject": "microsoft.graph.unifiedroleassignmentmultiple",
+    "SideIndicator": "<="
+  }
+]
+'@ | ConvertFrom-Json
+
+        $incorrectTypeDiff = @'
+[
+  {
+    "InputObject": "microsoft.graph.appscope",
+    "SideIndicator": "<="
+  },
+  {
+    "InputObject": "microsoft.graph.grouppolicyobjectfile",
+    "SideIndicator": "<="
+  },
+  {
+    "InputObject": "microsoft.graph.unifiedroleassignmentmultiple",
+    "SideIndicator": "<="
+  }
+]
+'@ | ConvertFrom-Json
+
+        It "Should throw an exception if a new graph is created with the same name as an existing graph" {
+
+            $originalGraph = new-graph originalGraph
+
+            { $duplicatedNameGraph = new-graph $originalGraph.Name } | Should Throw
+        }
+
+        It "Should return the correct difference between two graphs mounted from local metadata" {
+
+            $referenceGraph = new-graph -SchemaUri $ReferenceMetadataPath
+            $differenceGraph = new-graph -SchemaUri $DifferenceMetadataPath
+
+            $referenceTypes = Get-GraphType -list -GraphName $referenceGraph.Name
+            $differenceTypes = Get-GraphType -list -Graphname $differenceGraph.Name
+
+            ( $referenceTypes | measure-object ).Count | Should Be 1036
+            ( $differenceTypes | measure-object ).Count | Should Be 1032
+
+            $actualTypeDiff = Compare-Object $referenceTypes $differenceTypes
+
+            Compare-Object $actualTypeDiff $incorrectTypeDiff | Should Not Be $null
+            Compare-Object $actualTypeDiff $expectedTypeDiff | Should Be $null
+        }
+    }
+}

--- a/src/cmdlets/new-graph.tests.ps1
+++ b/src/cmdlets/new-graph.tests.ps1
@@ -73,19 +73,28 @@ Describe 'The New-Graph cmdlet' {
 
         It "Should return the correct difference between two graphs mounted from local metadata" {
 
+            write-host 'starting difference test'
             $referenceGraph = new-graph -SchemaUri $ReferenceMetadataPath
+            write-host 'created reference graph'
             $differenceGraph = new-graph -SchemaUri $DifferenceMetadataPath
+            write-host 'created difference graph'
 
             $referenceTypes = Get-GraphType -list -GraphName $referenceGraph.Name
+            write-host 'got reference types'
             $differenceTypes = Get-GraphType -list -Graphname $differenceGraph.Name
+            write-host 'got difference types'
 
             ( $referenceTypes | measure-object ).Count | Should Be 1036
             ( $differenceTypes | measure-object ).Count | Should Be 1032
+            write-host 'obtained correct counts'
 
             $actualTypeDiff = Compare-Object $referenceTypes $differenceTypes
+            write-host 'created actual diff'
 
             Compare-Object $actualTypeDiff $incorrectTypeDiff | Should Not Be $null
+            write-host 'compared against incorrect diff'
             Compare-Object $actualTypeDiff $expectedTypeDiff | Should Be $null
+            write-host 'compared against actual diff'
         }
     }
 }

--- a/src/metadata/EntityGraph.ps1
+++ b/src/metadata/EntityGraph.ps1
@@ -27,6 +27,7 @@ ScriptClass EntityGraph {
     $defaultNamespace = $null
     $dataModel = $null
     $builder = $null
+    $id = $null
 
     function __initialize($defaultNamespace, $apiVersion = 'localtest', [Uri] $endpoint = 'http://localhost', $dataModel) {
         $this.defaultNamespace = $defaultNamespace
@@ -38,6 +39,7 @@ ScriptClass EntityGraph {
         $this.Endpoint = $endpoint
         $this.dataModel = $dataModel
         $this.builder = new-so GraphBuilder $endpoint $apiVersion $dataModel
+        $this.id = [guid]::newguid()
     }
 
     function GetRootVertices {

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -35,7 +35,7 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
     }
 
     function GetGraph($endpointUri, $apiVersion = 'v1.0', $metadata = $null, $schemaId, $schemaUri) {
-        $graph = FindGraph $endpoint $apiVersion $schemaId
+        $graph = FindGraph $endpointUri $apiVersion $schemaId
 
         if ( $graph ) {
             $graph
@@ -255,7 +255,7 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
                     Get-Content $schemaUri
                 } else {
                     write-debug "Reading from remote URI '$schemaUri'"
-                    Invoke-GraphApiRequest -connection $connection '$metadata' -version $apiversion -erroraction stop -rawcontent -verbose
+                    Invoke-GraphApiRequest -connection $connection '$metadata' -version $apiversion -erroraction stop -rawcontent
                 }
 
                 write-debug "Finished reading schema content"

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -1,4 +1,4 @@
-# Copyright 2021, Adam Edwards
+# Copyright 2024, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,31 +34,31 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         $this.graphVersions = @{}
     }
 
-    function GetGraph($endpoint, $apiVersion = 'v1.0', $metadata = $null) {
-        $graph = FindGraph $endpoint $apiVersion
+    function GetGraph($endpointUri, $apiVersion = 'v1.0', $metadata = $null, $schemaId, $schemaUri) {
+        $graph = FindGraph $endpoint $apiVersion $schemaId
 
         if ( $graph ) {
             $graph
         } else {
-            $graphJob = GetGraphAsync $endpoint $apiVersion $metadata
+            $graphJob = GetGraphAsync $endpointUri $apiVersion $metadata $schemaId $schemaUri
             WaitForGraphAsync $graphJob
         }
     }
 
-    function FindGraph($endpoint, $apiVersion) {
-        $graphId = $this.scriptclass |=> __GetGraphId $endpoint $apiVersion
+    function FindGraph($endpoint, $apiVersion, $schemaId) {
+        $graphId = $this.scriptclass |=> __GetGraphId $endpoint $apiVersion $schemaId
         $this.graphVersions[$graphId]
     }
 
-    function GetGraphAsync($endpoint, $apiVersion = 'v1.0', $metadata = $null) {
-        $graphid = $this.scriptclass |=> __GetGraphId $endpoint $apiVersion
+    function GetGraphAsync($endpoint, $apiVersion = 'v1.0', $metadata = $null, $schemaId, $schemaUri) {
+        $graphId = $this.scriptclass |=> __GetGraphId $endpoint $apiVersion $schemaId
         $existingJob = $this.graphVersionsPending[$graphId]
         if ( $existingJob ) {
             write-verbose "Found existing job '$($existingJob.job.id)' for '$graphId'"
             $existingJob
         } else {
             write-verbose "No existing job for '$graphId' -- queueing up a new job"
-            __GetGraphAsync $graphId $endpoint $apiVersion $metadata
+            __GetGraphAsync $graphId $endpoint $apiVersion $metadata $schemaId $schemaUri
         }
     }
 
@@ -92,7 +92,23 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
             if ( (get-job $submittedVersion.job.id).State -eq 'Running' ) {
                 . $metadataWarningBlock
             }
-            receive-job -wait $submittedVersion.Job -erroraction stop
+
+            $elapsedMs = 0
+            $waitIntervalMs = 10000
+            $resultJob = $null
+            # Use a busy wait of sorts to avoid deadlocks
+            while ( $elapsedMs -lt (60 * $waitIntervalMs) -and ! (
+                        $resultJob = $submittedVersion.job | wait-job -timeout $waitIntervalMs -erroraction stop ) ) {
+                $elapsedMs += $waitIntervalMs
+            }
+
+            if ( ! $resultJob ) {
+                throw "Metadata processing job failed to complete after $elapsedMs milliseconds";
+            }
+
+            write-verbose "Receiving job"
+            $resultJob | receive-job -erroraction stop
+            write-verbose "Received job"
         } catch {
             $jobException = $_.exception
         }
@@ -149,8 +165,8 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         }
     }
 
-    function GetMetadataStatus($endpoint, $apiVersion) {
-        $graphid = $this.scriptclass |=> __GetGraphId $endpoint $apiversion
+    function GetMetadataStatus($endpoint, $apiVersion, $schemaId) {
+        $graphid = $this.scriptclass |=> __GetGraphId $endpoint $apiversion $schemaId
         $status = [MetadataStatus]::NotStarted
 
         if ($this.Graphversions[$graphId] -ne $null) {
@@ -171,9 +187,9 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         $status
     }
 
-    function __GetGraphAsync($graphId, $endpoint, $apiVersion, $metadata) {
-        write-verbose "Getting async graph for graphid: '$graphId', endpoint: '$endpoint', version: '$apiVersion'"
-        write-verbose "Local metadata supplied: '$($metadata -ne $null)'"
+    function __GetGraphAsync($graphId, $endpoint, $apiVersion, $metadata, $schemaId, $schemaUri) {
+        write-verbose "Getting async graph for graphid: '$graphId', endpoint: '$endpoint', version: '$apiVersion' at URI '$schemaUri'"
+        write-verbose "Local metadata supplied: '$($metadata -ne $null)' with id '$schemaId'"
 
         $cacheClass = $::.GraphCache
 
@@ -184,7 +200,7 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         # deserialize objects -- many of the strange workarounds in this module to ensure that ScriptClass object state was preserved is no longer
         # a necessity, though most of those workarounds are now built in to ScriptClass itself. It may even be feasible to parse the entire graph
         # rather than only parse just in time since the entire graph can be parsed efficiently in the background without being serialized and deserialized.
-        $graphLoadJob = Start-ThreadJob { param($cacheClass, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; $cacheClass.__GetGraph($graphEndpoint, $version, $schemadata) } -argumentlist $cacheClass, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
+        $graphLoadJob = Start-ThreadJob { param($cacheClass, $graphEndpoint, $version, $schemadata, $schemaId, $schemaUri, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; $cacheClass.__GetGraph($graphEndpoint, $version, $schemadata, $schemaId, $schemaUri) } -argumentlist $cacheClass, $endpoint, $apiVersion, $metadata, $schemaId, $schemaUri, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
 
         $graphAsyncJob = [PSCustomObject]@{Job=$graphLoadJob;Id=$graphId}
         write-verbose "Saving job '$($graphLoadJob.Id) for graphid '$graphId'"
@@ -193,30 +209,62 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
     }
 
     static {
-        function __GetGraph($endpoint, $apiVersion, $metadata) {
-            $graphId = __GetGraphId $endpoint $apiVersion
+        function __GetGraph($endpoint, $apiVersion, $metadata, $schemaId, $schemaUri) {
+            $graphId = __GetGraphId $endpoint $apiVersion $schemaId
             $schemadata = if ( $metadata ) {
                 write-verbose "Using locally supplied metadata, skipping retrieval from remote Graph"
                 $metadata
             } else {
-                __GetSchema $endpoint $apiVersion
+                __GetSchema $endpoint $apiVersion $schemaUri
             }
             [PSCustomObject]@{Id=$graphId;SchemaData=$schemadata;Endpoint=$endpoint;Version=$apiVersion}
         }
 
-        function __GetGraphId($endpoint, $apiVersion) {
-            "{0}:{1}" -f $endpoint, $apiVersion
+        function __GetGraphId($endpoint, $apiVersion, $schemaId) {
+            if ( $schemaId ) {
+                "id=$($schemaId)"
+            } else {
+                "{0}:{1}" -f $endpoint, $apiVersion
+            }
         }
 
-        function __GetSchema($endpoint, $apiVersion) {
-            $metadataActivity = "Reading metadata for graph version '$apiversion' from endpoint '$endpoint'"
+        function __GetSchema([Uri] $endpointUri, $apiVersion, $schemaUri) {
+            if ( ! $schemaUri ) {
+                throw 'An empty schema URI was specified'
+            }
+
+            $fromLocal = switch ( ( [Uri] $schemaUri ).scheme ) {
+                'file' { $true }
+                'https' { $false }
+                default {
+                    throw "The specified URI '$schemaUri' did not conform to a valid file or https scheme"
+                }
+            }
+
+            $metadataActivity = "Reading metadata for graph version '$apiversion' for endpoint '$endpoint' from URI $schemaUri"
             Write-Progress -id 1 -activity $metadataactivity -status "Downloading"
 
-            $graphEndpoint = new-so GraphEndpoint Public $endpoint http://localhost 'Default'
+            $graphEndpoint = new-so GraphEndpoint Custom $endpointUri http://localhost 'Default'
             $connection = new-so GraphConnection $graphEndpoint $null $null
 
             $schema = try {
-                Invoke-GraphApiRequest -connection $connection '$metadata' -version $apiversion -erroraction stop -rawcontent
+                write-verbose 'Sending request'
+
+                $schemaContent = if ( $fromLocal ) {
+                    write-debug "Reading from local file '$schemaUri'"
+                    Get-Content $schemaUri
+                } else {
+                    write-debug "Reading from remote URI '$schemaUri'"
+                    Invoke-GraphApiRequest -connection $connection '$metadata' -version $apiversion -erroraction stop -rawcontent -verbose
+                }
+
+                write-debug "Finished reading schema content"
+                write-debug "Parsing schema content as XML"
+
+                [xml] ( $schemaContent | out-string )
+
+                write-debug "Completed parsing of schema content as XML"
+                write-verbose 'Request completed'
             } catch {
                 write-verbose "Invoke-GraphApiRequest failed to download schema"
                 write-verbose $_
@@ -225,7 +273,9 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
             }
 
             Write-Progress -id 1 -activity $metadataactivity -status "Download complete" -completed
+
             $schema
         }
     }
 }
+

--- a/src/typesystem/TypeManager.ps1
+++ b/src/typesystem/TypeManager.ps1
@@ -30,6 +30,7 @@ ScriptClass TypeManager {
     $hasRequiredTypeDefinitions = $false
     $typeProviders = $null
     $typeSearcher = $null
+    $id = $null
 
     function __initialize($graphContext) {
         $this.graphContext = $graphContext
@@ -40,6 +41,7 @@ ScriptClass TypeManager {
             $true = @{}
         }
         $this.typeProviders = @{}
+        $this.id = [guid]::newguid()
     }
 
     function GetPrototype($typeClass, $typeName, $fullyQualified = $false, $setDefaultValues = $false, $recursive = $false, $propertyFilter, [object[]] $valueList, $propertyList, $skipPropertyCheck, [bool] $isCollection) {


### PR DESCRIPTION
### Description

Update to new AutoGraphPS-SDK, MSAL, and custom API metadata improvements.

### New dependencies

* AutoGraphPS-SDK 0.31.0
* Microsft.Identity.Client 4.64.0 -- i.e. MSAL

### Breaking changes

None.

### New features

* The `New-Graph` command supports two new parameters to enable custom API metadata:
  *  The `SchemaUri` parameter: this can point to a remote https scheme URI or even a local file system path
     that conatins the OData metadata document for the API specification that defines the graph structure, i.e.
     the same kind of content that is available at real API versions such as https://graph.microsoft.com/v1.0/$metadata.
  *  The `SchemaMetadata` parameter: this is the actual content of the API schema document; it may be useful to specify this
     in cases where the metadata has been downloaded or constructed out of band of any commands

### Fixed defects

* `Remove-Graph` was completely broken, it would always throw an exception and not remove the graph. This is fixed.

### Checklist

- [x] New test coverage was added for the new functionality
- [x] All project tests pass successfully